### PR TITLE
Refactor/use stl algorithms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
           --template=gcc
           --enable=style,performance,warning,portability
           --std=c++17
-          --suppress=useStlAlgorithm
           --suppress=noExplicitConstructor
           --suppress=operatorEqVarError
           --error-exitcode=1

--- a/benchmarks/bspline/bench_bspline.cpp
+++ b/benchmarks/bspline/bench_bspline.cpp
@@ -104,10 +104,12 @@ TEST_CASE(
 
       y_data.clear();
       y_data.reserve(x_data.size());
-      for (auto x : x_data)
-      {
-        y_data.push_back(bspline.evaluate(x));
-      }
+      std::transform(
+          x_data.begin(),
+          x_data.end(),
+          std::back_inserter(y_data),
+          [&bspline](double x) { return bspline.evaluate(x); }
+      );
 
       BENCHMARK(
           "bspline.fit - knots: " + std::to_string(knots_num) +

--- a/benchmarks/bspline/bench_bspline.cpp
+++ b/benchmarks/bspline/bench_bspline.cpp
@@ -7,8 +7,9 @@
 #include <vector>
 
 // Third-party includes
-#include <catch2/benchmark/catch_benchmark_all.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/benchmark/catch_chronometer.hpp>
+#include <catch2/benchmark/catch_constructor.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 // BSplineX includes
@@ -16,8 +17,6 @@
 #include "BSplineX/control_points/c_data.hpp"
 #include "BSplineX/knots/t_data.hpp"
 #include "BSplineX/types.hpp"
-#include "catch2/benchmark/catch_benchmark.hpp"
-#include "catch2/benchmark/catch_constructor.hpp"
 
 using namespace bsplinex;
 using namespace bsplinex::bspline;

--- a/benchmarks/bspline/bench_bspline.cpp
+++ b/benchmarks/bspline/bench_bspline.cpp
@@ -1,6 +1,8 @@
 // Standard includes
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <iterator>
 #include <string>
 #include <vector>
 

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -189,15 +189,15 @@ public:
    */
   [[nodiscard]] std::vector<T>
   evaluate(std::vector<T> const &values, size_t derivative_order = 0) const
-
   {
     std::vector<T> results;
     results.reserve(values.size());
-
-    for (auto const &value : values)
-    {
-      results.push_back(this->evaluate(value, derivative_order));
-    }
+    std::transform(
+        values.begin(),
+        values.end(),
+        std::back_inserter(results),
+        [this, derivative_order](T x) { return this->evaluate(x, derivative_order); }
+    );
 
     return results;
   }
@@ -389,25 +389,25 @@ public:
 
   [[nodiscard]] std::vector<T> get_control_points() const
   {
-    std::vector<T> ctrl_pts;
-    ctrl_pts.reserve(this->control_points.size());
-
-    for (size_t i{0}; i < this->control_points.size(); i++)
-    {
-      ctrl_pts.push_back(this->control_points.at(i));
-    }
-
-    return ctrl_pts;
+    std::vector<T> control_points_vec;
+    control_points_vec.reserve(this->control_points.size());
+    std::generate_n(
+        std::back_inserter(control_points_vec),
+        this->control_points.size(),
+        [this, i = 0]() mutable { return this->control_points.at(i++); }
+    );
+    return control_points_vec;
   }
 
   [[nodiscard]] std::vector<T> get_knots() const
   {
     std::vector<T> knots_vec;
     knots_vec.reserve(this->knots.size());
-    for (size_t i{0}; i < this->knots.size(); i++)
-    {
-      knots_vec.push_back(this->knots.at(i));
-    }
+    std::generate_n(
+        std::back_inserter(knots_vec),
+        this->knots.size(),
+        [this, i = 0]() mutable { return this->knots.at(i++); }
+    );
 
     return knots_vec;
   }

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -49,7 +49,7 @@ private:
   control_points::ControlPoints<T, BC> control_points{};
   size_t degree{};
   std::vector<T> mutable support{};
-  std::unique_ptr<BSpline> mutable derivative_ptr;
+  std::unique_ptr<BSpline const> mutable derivative_ptr;
 
 public:
   /**
@@ -548,7 +548,7 @@ private:
     if (not this->derivative_ptr)
     {
       debugassert(this->degree > 0, "Cannot compute derivative of a 0-degree bspline");
-      this->derivative_ptr = std::unique_ptr<BSpline>(new BSpline(
+      this->derivative_ptr = std::unique_ptr<BSpline const>(new BSpline(
           this->knots.get_derivative_knots(),
           this->control_points.get_derivative_control_points(this->knots),
           this->degree - 1

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -226,8 +226,9 @@ public:
     auto [index, basis_functions] = this->nnz_basis(value, derivative_order);
 
     basis_functions.insert(basis_functions.begin(), index, ZERO<T>);
-    basis_functions
-        .insert(basis_functions.end(), this->control_points.size() - index - this->degree - 1, ZERO<T>);
+    basis_functions.insert(
+        basis_functions.end(), this->control_points.size() - index - this->degree - 1, ZERO<T>
+    );
 
     return basis_functions;
   }
@@ -264,15 +265,19 @@ public:
   {
     releaseassert(x.size() == y.size(), "x and y must have the same size");
 
-    this->control_points = std::move(lsq::lsq<T, vec_const_iter, BC>(
-        this->degree,
-        this->knots.size(),
-        [this](T value, size_t derivative_order, std::vector<T> &vec) -> size_t
-        { return this->nnz_basis<vec_iter>(value, derivative_order, {vec.begin(), vec.end()}); },
-        vec_const_view{x.begin(), x.end()},
-        vec_const_view{y.begin(), y.end()},
-        {}
-    ));
+    this->control_points = std::move(
+        lsq::lsq<T, vec_const_iter, BC>(
+            this->degree,
+            this->knots.size(),
+            [this](T value, size_t derivative_order, std::vector<T> &vec) -> size_t
+            {
+              return this->nnz_basis<vec_iter>(value, derivative_order, {vec.begin(), vec.end()});
+            },
+            vec_const_view{x.begin(), x.end()},
+            vec_const_view{y.begin(), y.end()},
+            {}
+        )
+    );
     this->invalidate_derivative();
   }
 
@@ -319,16 +324,7 @@ public:
       );
     }
 
-    knots::Knots<T, C, BC, EXT> new_knots;
-    if constexpr (Curve::UNIFORM == C)
-    {
-      releaseassert(is_uniform(x), "x is not uniform");
-      new_knots = std::move(knots::Knots<T, C, BC, EXT>{{x.front(), x.back(), x.size()}, degree});
-    }
-    else
-    {
-      new_knots = std::move(knots::Knots<T, C, BC, EXT>{{x}, degree});
-    }
+    knots::Knots<T, C, BC, EXT> new_knots{{x}, degree};
 
     auto const knots_domain = new_knots.domain();
     releaseassert(
@@ -365,18 +361,21 @@ public:
       static_assert(false, "Unknown boundary condition, you should never get here!");
     }
 
-    this->control_points = std::move(lsq::lsq<T, vec_const_iter, BC>(
-        this->degree,
-        this->knots.size(),
-        [this](T value, size_t derivative_order, std::vector<T> &vec) -> size_t {
-          return this->template nnz_basis<vec_iter>(
-              value, derivative_order, {vec.begin(), vec.end()}
-          );
-        },
-        x_view,
-        y_view,
-        additional_conditions
-    ));
+    this->control_points = std::move(
+        lsq::lsq<T, vec_const_iter, BC>(
+            this->degree,
+            this->knots.size(),
+            [this](T value, size_t derivative_order, std::vector<T> &vec) -> size_t
+            {
+              return this->template nnz_basis<vec_iter>(
+                  value, derivative_order, {vec.begin(), vec.end()}
+              );
+            },
+            x_view,
+            y_view,
+            additional_conditions
+        )
+    );
 
     this->invalidate_derivative();
   }
@@ -575,29 +574,6 @@ private:
   }
 
   void invalidate_derivative() const { this->derivative_ptr = nullptr; }
-
-  static bool is_uniform(std::vector<T> const &x)
-  {
-    if (x.size() < 2)
-    {
-      return true;
-    }
-
-    T const expected_step = std::abs(x.at(1) - x.at(0));
-
-    return std::adjacent_find(
-               x.begin(),
-               x.end() - 1,
-               [expected_step](T a, T b)
-               {
-                 T const actual_step = std::abs(b - a);
-                 T const diff        = std::abs(actual_step - expected_step);
-                 T const max_val     = std::max(actual_step, expected_step);
-
-                 return not(diff <= RTOL<T> * max_val or diff <= ATOL<T>);
-               }
-           ) == x.end() - 1;
-  }
 };
 
 } // namespace bsplinex::bspline

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -568,7 +568,7 @@ private:
   BSpline const *get_derivative(size_t derivative_order) const
   {
     releaseassert(
-        (0 < derivative_order) && (derivative_order <= this->degree),
+        (0 < derivative_order) and (derivative_order <= this->degree),
         "derivative_order must be in [1, degree]"
     );
     BSpline const *d = this;

--- a/include/BSplineX/control_points/c_atter.hpp
+++ b/include/BSplineX/control_points/c_atter.hpp
@@ -77,14 +77,15 @@ public:
 
   [[nodiscard]] std::vector<T> get_values() const
   {
-    std::vector<T> values(data.size() + padder.size());
+    std::vector<T> values;
+    values.reserve(data.size() + padder.size());
     for (size_t i = 0; i < data.size(); i++)
     {
-      values[i] = data.at(i);
+      values.push_back(data.at(i));
     }
     for (size_t i = 0; i < padder.size(); i++)
     {
-      values[data.size() + i] = padder.right(i);
+      values.push_back(padder.right(i));
     }
     return values;
   }

--- a/include/BSplineX/defines.hpp
+++ b/include/BSplineX/defines.hpp
@@ -12,7 +12,7 @@
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define debugassert(exp, msg) assert(((void)(msg), exp))
 #define releaseassert(exp, msg)                                                                    \
-  if (!(exp))                                                                                      \
+  if (not(exp))                                                                                    \
     throw std::runtime_error(msg);
 
 #ifdef BSPLINEX_DEBUG_LOG_CALL

--- a/include/BSplineX/defines.hpp
+++ b/include/BSplineX/defines.hpp
@@ -4,6 +4,10 @@
 #include <cassert>
 #include <cstddef>
 #include <limits>
+#include <stdexcept>
+
+// avoids clangd/clang-tidy complaining about unused header stdexcept
+[[maybe_unused]] constexpr auto use_stdexcept = sizeof(std::runtime_error);
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define debugassert(exp, msg) assert(((void)(msg), exp))

--- a/include/BSplineX/knots/knots.hpp
+++ b/include/BSplineX/knots/knots.hpp
@@ -112,7 +112,7 @@ public:
 
   [[nodiscard]] std::pair<size_t, T> find(T value) const
   {
-    if (value < this->value_left || value > this->value_right)
+    if (value < this->value_left or value > this->value_right)
     {
       value = this->extrapolator.extrapolate(value);
     }

--- a/include/BSplineX/knots/t_data.hpp
+++ b/include/BSplineX/knots/t_data.hpp
@@ -50,6 +50,16 @@ public:
     this->end       = begin + (this->num_elems - 1) * step;
   }
 
+  Data(std::vector<T> const &data)
+  {
+    releaseassert(Data::is_uniform(data), "data is not uniform");
+
+    this->begin     = data.front();
+    this->end       = data.back();
+    this->num_elems = data.size();
+    this->step_size = (this->end - this->begin) / (this->num_elems - 1);
+  }
+
   // Specifying the num-elems means the domain will be [begin, end]
   Data(T begin, T end, size_t num_elems)
   {
@@ -134,6 +144,30 @@ public:
     this->begin     += this->step_size;
     this->end       -= this->step_size;
     this->num_elems -= 2;
+  }
+
+private:
+  static bool is_uniform(std::vector<T> const &x)
+  {
+    if (x.size() < 2)
+    {
+      return true;
+    }
+
+    T const expected_step = std::abs(x.at(1) - x.at(0));
+
+    return std::adjacent_find(
+               x.begin(),
+               x.end() - 1,
+               [expected_step](T a, T b)
+               {
+                 T const actual_step = std::abs(b - a);
+                 T const diff        = std::abs(actual_step - expected_step);
+                 T const max_val     = std::max(actual_step, expected_step);
+
+                 return not(diff <= constants::RTOL<T> * max_val or diff <= constants::ATOL<T>);
+               }
+           ) == x.end() - 1;
   }
 };
 

--- a/include/BSplineX/knots/t_data.hpp
+++ b/include/BSplineX/knots/t_data.hpp
@@ -121,11 +121,9 @@ public:
 
     std::vector<T> tmp{};
     tmp.reserve(last - first);
-
-    for (size_t i{first}; i < last; i++)
-    {
-      tmp.push_back(this->at(i));
-    }
+    std::generate_n(
+        std::back_inserter(tmp), last - first, [this, i = first]() mutable { return this->at(i++); }
+    );
 
     return tmp;
   }

--- a/include/BSplineX/knots/t_extrapolator.hpp
+++ b/include/BSplineX/knots/t_extrapolator.hpp
@@ -96,7 +96,7 @@ public:
   [[nodiscard]] T extrapolate(T value) const
   {
     debugassert(
-        value < this->value_left || value > this->value_right, "Value not outside of the domain"
+        value < this->value_left or value > this->value_right, "Value not outside of the domain"
     );
     return value < this->value_left ? this->value_left : this->value_right;
   }
@@ -165,7 +165,7 @@ public:
   [[nodiscard]] T extrapolate(T value) const
   {
     debugassert(
-        value < this->value_left || value > this->value_right, "Value not outside of the domain"
+        value < this->value_left or value > this->value_right, "Value not outside of the domain"
     );
 
     T wrapped = std::fmod<T>(value - this->value_left, this->period);

--- a/include/BSplineX/knots/t_extrapolator.hpp
+++ b/include/BSplineX/knots/t_extrapolator.hpp
@@ -4,7 +4,6 @@
 // Standard includes
 #include <cmath>
 #include <cstddef>
-#include <stdexcept>
 
 // BSplineX includes
 #include "BSplineX/defines.hpp"

--- a/include/BSplineX/knots/t_finder.hpp
+++ b/include/BSplineX/knots/t_finder.hpp
@@ -45,7 +45,7 @@ public:
   [[nodiscard]] size_t find(T value) const
   {
     debugassert(
-        value >= this->atter->at(this->index_left) && value <= this->atter->at(this->index_right),
+        value >= this->atter->at(this->index_left) and value <= this->atter->at(this->index_right),
         "Value outside of the domain"
     );
 
@@ -91,7 +91,7 @@ public:
   [[nodiscard]] size_t find(T value) const
   {
     debugassert(
-        value >= this->value_left && value <= this->value_right, "Value outside of the domain"
+        value >= this->value_left and value <= this->value_right, "Value outside of the domain"
     );
 
     size_t const index =

--- a/include/BSplineX/knots/t_padder.hpp
+++ b/include/BSplineX/knots/t_padder.hpp
@@ -257,8 +257,8 @@ public:
 
   void pop_tails()
   {
-    debugassert(!this->pad_left.empty(), "Cannot pop tails from an empty domain");
-    debugassert(!this->pad_right.empty(), "Cannot pop tails from an empty domain");
+    debugassert(not this->pad_left.empty(), "Cannot pop tails from an empty domain");
+    debugassert(not this->pad_right.empty(), "Cannot pop tails from an empty domain");
     this->pad_left.erase(this->pad_left.begin());
     this->pad_right.pop_back();
   }

--- a/tests/bspline/test_bspline_with_data.cpp
+++ b/tests/bspline/test_bspline_with_data.cpp
@@ -102,7 +102,7 @@ BSplineType build_bspline(std::vector<real_t> knots, std::vector<real_t> ctrl_pt
     real_t knots_end   = knots.back();
     size_t num_knots   = knots.size();
 
-    if (BoundaryCondition::CLAMPED == BSplineType::boundary_condition_type ||
+    if (BoundaryCondition::CLAMPED == BSplineType::boundary_condition_type or
         BoundaryCondition::PERIODIC == BSplineType::boundary_condition_type)
     {
       knots_begin = knots[degree];
@@ -115,7 +115,7 @@ BSplineType build_bspline(std::vector<real_t> knots, std::vector<real_t> ctrl_pt
   else
   {
     static_assert(Curve::NON_UNIFORM == BSplineType::curve_type);
-    if (BoundaryCondition::CLAMPED == BSplineType::boundary_condition_type ||
+    if (BoundaryCondition::CLAMPED == BSplineType::boundary_condition_type or
         BoundaryCondition::PERIODIC == BSplineType::boundary_condition_type)
     {
       auto const deg = static_cast<int>(degree);

--- a/tests/bspline/test_bspline_with_data.cpp
+++ b/tests/bspline/test_bspline_with_data.cpp
@@ -281,13 +281,12 @@ TEMPLATE_TEST_CASE("BSpline", "[bspline][template][product]", BSPLINE_TEST_TYPES
           {
             std::vector<real_t> x_nnz;
             x_nnz.reserve(x_eval.size());
-            for (real_t const x : x_eval)
-            {
-              if (domain_l <= x && x <= domain_r)
-              {
-                x_nnz.push_back(x);
-              }
-            }
+            std::copy_if(
+                x_eval.begin(),
+                x_eval.end(),
+                std::back_inserter(x_nnz),
+                [domain_l, domain_r](real_t x) { return domain_l <= x && x <= domain_r; }
+            );
             REQUIRE(x_nnz.size() == test_data["bspline"]["nnz_basis"][derivative_order].size());
 
             for (size_t i = 0; i < x_nnz.size(); ++i)

--- a/tests/matchers.hpp
+++ b/tests/matchers.hpp
@@ -76,8 +76,8 @@ struct WithinAbsRelVectorMatcher final : Catch::Matchers::MatcherBase<std::vecto
 
     for (size_t i = 0; i < actual.size(); ++i)
     {
-      if (!Catch::Matchers::WithinRel(this->target[i], this->rtol).match(actual[i]) and
-          !Catch::Matchers::WithinAbs(this->target[i], this->atol).match(actual[i]))
+      if (not Catch::Matchers::WithinRel(this->target[i], this->rtol).match(actual[i]) and
+          not Catch::Matchers::WithinAbs(this->target[i], this->atol).match(actual[i]))
       {
         allMatch = false;
         this->failures.push_back({i, this->target[i], actual[i]});
@@ -99,7 +99,7 @@ struct WithinAbsRelVectorMatcher final : Catch::Matchers::MatcherBase<std::vecto
     }
     ss << "\n";
 
-    if (!this->mismatch_description.empty())
+    if (not this->mismatch_description.empty())
     {
       ss << this->mismatch_description;
       return ss.str();

--- a/tests/matchers.hpp
+++ b/tests/matchers.hpp
@@ -24,7 +24,7 @@ public:
   WithinAbsRelMatcher(T const target, T const rtol, T const atol)
       : target(target), rtol(rtol), atol(atol),
         rel_matcher(Catch::Matchers::WithinRel(target, rtol)),
-        abs_matcher(Catch::Matchers::WithinAbs(target, atol)), matcher(rel_matcher || abs_matcher)
+        abs_matcher(Catch::Matchers::WithinAbs(target, atol)), matcher(rel_matcher or abs_matcher)
   {
   }
 
@@ -76,7 +76,7 @@ struct WithinAbsRelVectorMatcher final : Catch::Matchers::MatcherBase<std::vecto
 
     for (size_t i = 0; i < actual.size(); ++i)
     {
-      if (!Catch::Matchers::WithinRel(this->target[i], this->rtol).match(actual[i]) &&
+      if (!Catch::Matchers::WithinRel(this->target[i], this->rtol).match(actual[i]) and
           !Catch::Matchers::WithinAbs(this->target[i], this->atol).match(actual[i]))
       {
         allMatch = false;
@@ -93,7 +93,7 @@ struct WithinAbsRelVectorMatcher final : Catch::Matchers::MatcherBase<std::vecto
     ss << "is within " << this->rtol << " relative tolerance and " << this->atol
        << " absolute tolerance of expected vector";
 
-    if (this->failures.empty() && this->mismatch_description.empty())
+    if (this->failures.empty() and this->mismatch_description.empty())
     {
       return "";
     }


### PR DESCRIPTION
Implements #12:
- use `std::transform`, `std::generate_n`, and `std::adjacent` when possible
- use `and`, `or`, `not` instead of `&&`, `||`, `!`