### PR TITLE
Refactor/avoid unused included header

### DIFF
--- a/.github/workflows/test_python_bindings_creation.yml
+++ b/.github/workflows/test_python_bindings_creation.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cd BSplineX-python
           rm -r BSplineX
-          ln -s ../BSplineX .
+          ln -s .. ./BSplineX
         shell: bash
 
       - name: "Test: generate Python bindings"

--- a/.github/workflows/test_python_bindings_creation.yml
+++ b/.github/workflows/test_python_bindings_creation.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: BSplineX/BSplineX-python
+          path: BSplineX-python
 
       - name: "Setup: create symlink to BSplineX"
         run: |

--- a/.github/workflows/test_python_bindings_creation.yml
+++ b/.github/workflows/test_python_bindings_creation.yml
@@ -2,6 +2,7 @@ name: Test Python Bindings Creation
 
 on:
   push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 jobs:

--- a/.github/workflows/test_python_bindings_creation.yml
+++ b/.github/workflows/test_python_bindings_creation.yml
@@ -1,0 +1,45 @@
+name: Test Python Bindings Creation
+
+on:
+  push:
+  pull_request:
+    branches: ["main"]
+jobs:
+  test:
+    name: Test Python bindings creation on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+
+    steps:
+      - name: "Setup: checkout repo"
+        uses: actions/checkout@v4
+
+      - name: "Setup: get CMake"
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: latestrc
+
+      - name: "Setup: get Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: "Setup: checkout Python bindings repo"
+        uses: actions/checkout@v4
+        with:
+          repository: BSplineX/BSplineX-python
+
+      - name: "Setup: create symlink to BSplineX"
+        run: |
+          cd BSplineX-python
+          rm -r BSplineX
+          ln -s ../BSplineX .
+        shell: bash
+
+      - name: "Test: generate Python bindings"
+        run: |
+          cd BSplineX-python
+          pip install . -U
+        shell: bash

--- a/.github/workflows/test_python_bindings_creation.yml
+++ b/.github/workflows/test_python_bindings_creation.yml
@@ -13,8 +13,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
 
     steps:
+      - name: "Setup: checkout Python bindings repo"
+        uses: actions/checkout@v4
+        with:
+          repository: BSplineX/BSplineX-python
+
       - name: "Setup: checkout repo"
         uses: actions/checkout@v4
+        with:
+          path: BSplineX
 
       - name: "Setup: get CMake"
         uses: lukka/get-cmake@latest
@@ -26,21 +33,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: "Setup: checkout Python bindings repo"
-        uses: actions/checkout@v4
-        with:
-          repository: BSplineX/BSplineX-python
-          path: BSplineX-python
-
-      - name: "Setup: create symlink to BSplineX"
-        run: |
-          cd BSplineX-python
-          rm -r BSplineX
-          ln -s .. ./BSplineX
-        shell: bash
-
       - name: "Test: generate Python bindings"
         run: |
-          cd BSplineX-python
           pip install . -U
         shell: bash

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ target_link_libraries(your_target PRIVATE BSplineX::BSplineX)
 ```
 
 If you already have `BSplineX` somewhere on your system, you can use
-`find_pacakge` directly.
+`find_package` directly.
 
 ```cmake
 # Optionally specify a custom path to find content from

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ int main()
   constexpr double max_knot{10.0};
   std::vector<double> ctrl_points{1.0, 0.3, 0.6, 0.9, 0.28, 9.32};
 
-  auto bspline = bsplinex::factory::clamped_uniform_constant(
+  auto bspline = bsplinex::clamped_uniform_constant(
     degree, min_knot, max_knot, num_knots, ctrl_points
   );
 
@@ -130,7 +130,7 @@ In the previous example, the knots are easy to understand: they are you discreti
 ...
 
   // Create the B-Spline without specifying the control points
-  auto bspline = bsplinex::factory::clamped_uniform_constant(
+  auto bspline = bsplinex::clamped_uniform_constant(
     degree, min_knot, max_knot, num_knots
   );
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ int main()
   constexpr double max_knot{10.0};
   std::vector<double> ctrl_points{1.0, 0.3, 0.6, 0.9, 0.28, 9.32};
 
-  auto bspline = bsplinex::clamped_uniform_constant(
+  auto bspline = bsplinex::make_clamped_uniform_constant(
     degree, min_knot, max_knot, num_knots, ctrl_points
   );
 
@@ -146,7 +146,7 @@ assuming we start from the previous example.
 ...
 
   // Create the B-Spline without specifying the control points
-  auto bspline = bsplinex::clamped_uniform_constant(
+  auto bspline = bsplinex::make_clamped_uniform_constant(
     degree, min_knot, max_knot, num_knots
   );
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BSplineX
 
-The B-Spline library you have always dreamed of where performance and easy-to-use interfaces live in harmony.
+The B-Spline library you have always dreamed of where performance and
+easy-to-use interfaces live in harmony.
 
 ## Features
 
@@ -16,7 +17,10 @@ This is a non-exhaustive list of the currently supported features.
 
 ### Quick and dirty
 
-`BSplineX` is a header-only library that depends only on `Eigen`, so the quick and dirty way of installing it is by simply copying the `include` directory to your project and make sure to have `Eigen` available however you see fit. Alternatively, you can do things properly and use `CMake`.
+`BSplineX` is a header-only library that depends only on `Eigen`, so the quick
+and dirty way of installing it is by simply copying the `include` directory to
+your project and make sure to have `Eigen` available however you see fit.
+Alternatively, you can do things properly and use `CMake`.
 
 ### CMake
 
@@ -43,7 +47,8 @@ fetchcontent_makeavailable(BSplineX)
 target_link_libraries(your_target PRIVATE BSplineX::BSplineX)
 ```
 
-If you already have `BSplineX` somewhere on your system, you can use `find_pacakge` directly.
+If you already have `BSplineX` somewhere on your system, you can use
+`find_pacakge` directly.
 
 ```cmake
 # Optionally specify a custom path to find content from
@@ -57,7 +62,8 @@ find_package(
 target_link_libraries(your_target PRIVATE BSplineX::BSplineX)
 ```
 
-Since we are nice people, we also show you how to conditionally use `FetchContent` based if you already have the library or not.
+Since we are nice people, we also show you how to conditionally use
+`FetchContent` based if you already have the library or not.
 
 ```cmake
 # Optionally specify a custom path to find content from
@@ -87,7 +93,8 @@ target_link_libraries(your_target PRIVATE BSplineX::BSplineX)
 
 ## Usage
 
-`BSplineX` is extremely easy to use, everything that is complex about B-Splines is hidden behind the curtain. Hereafter some quick examples.
+`BSplineX` is extremely easy to use, everything that is complex about B-Splines
+is hidden behind the curtain. Hereafter some quick examples.
 
 ### Creating a 1D B-Spline
 
@@ -118,13 +125,22 @@ int main()
 }
 ```
 
-If you want to make it periodic or open, just change the template parameter, easy. Want to pass in a non-uniform knot sequence? Piece of cake, just set the `Curve` template parameter to `Curve::NON_UNIFORM` and pass in your knots vector. Boom, done, simple.
+If you want to make it periodic or open, just change the template parameter,
+easy. Want to pass in a non-uniform knot sequence? Piece of cake, just set the
+`Curve` template parameter to `Curve::NON_UNIFORM` and pass in your knots
+vector. Boom, done, simple.
 
-Now I know what you are thinking: "Dude, cool, but how on earth do I know which control points to use?". Fear not, and follow along ;).
+Now I know what you are thinking: "Dude, cool, but how on earth do I know which
+control points to use?". Fear not, and follow along ;).
 
 ### Fitting a 1D B-Spline
 
-In the previous example, the knots are easy to understand: they are you discretisation grid, so you just have to choose how you want to discretise along that dimension. Control points on the other hand are not easily graspable. Fortunately you don't really need to know them a priori, you can just interpolate (coming soon!) or fit some data points. Let's see how, assuming we start from the previous example.
+In the previous example, the knots are easy to understand: they are you
+discretisation grid, so you just have to choose how you want to discretise
+along that dimension. Control points on the other hand are not easily
+graspable. Fortunately you don't really need to know them a priori, you can
+just interpolate (coming soon!) or fit some data points. Let's see how,
+assuming we start from the previous example.
 
 ```cpp
 ...
@@ -151,4 +167,9 @@ See the [examples](examples) folder for some more examples on how to use the lib
 
 ## Performance
 
-`BSplineX` is all about performance. In fact, aside from being a cool and useful project, it is our playground to understand modern code optimisation techniques. Our goal is to be as fast as humanly possible (albeit without having to re-write the library by hand in assembly). Hereafter a non-exhaustive quick table with some performance results. If you want to can run the benchmarks on your own PC.
+`BSplineX` is all about performance. In fact, aside from being a cool and
+useful project, it is our playground to understand modern code optimisation
+techniques. Our goal is to be as fast as humanly possible (albeit without
+having to re-write the library by hand in assembly). Hereafter a non-exhaustive
+quick table with some performance results. If you want to can run the
+benchmarks on your own PC.

--- a/bindings/BSplineX.i
+++ b/bindings/BSplineX.i
@@ -42,40 +42,40 @@ using namespace bsplinex;
 
 %template(OpenUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::OPEN, Extrapolation::NONE>;
 %template() types::OpenUniform<double>;
-%template(open_uniform) factory::open_uniform<double>;
+%template(open_uniform) factory::make_open_uniform<double>;
 
 %template(OpenUniformConstant) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::OPEN, Extrapolation::CONSTANT>;
 %template() types::OpenUniformConstant<double>;
-%template(open_uniform_constant) factory::open_uniform_constant<double>;
+%template(open_uniform_constant) factory::make_open_uniform_constant<double>;
 
 %template(OpenNonUniform) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::OPEN, Extrapolation::NONE>;
 %template() types::OpenNonUniform<double>;
-%template(open_nonuniform) factory::open_nonuniform<double>;
+%template(open_nonuniform) factory::make_open_nonuniform<double>;
 
 %template(OpenNonUniformConstant) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::OPEN, Extrapolation::CONSTANT>;
 %template() types::OpenNonUniformConstant<double>;
-%template(open_nonuniform_constant) factory::open_nonuniform_constant<double>;
+%template(open_nonuniform_constant) factory::make_open_nonuniform_constant<double>;
 
 %template(ClampedUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::NONE>;
 %template() types::ClampedUniform<double>;
-%template(clamped_uniform) factory::clamped_uniform<double>;
+%template(clamped_uniform) factory::make_clamped_uniform<double>;
 
 %template(ClampedUniformConstant) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::CONSTANT>;
 %template() types::ClampedUniformConstant<double>;
-%template(clamped_uniform_constant) factory::clamped_uniform_constant<double>;
+%template(clamped_uniform_constant) factory::make_clamped_uniform_constant<double>;
 
 %template(ClampedNonUniform) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::NONE>;
 %template() types::ClampedNonUniform<double>;
-%template(clamped_nonuniform) factory::clamped_nonuniform<double>;
+%template(clamped_nonuniform) factory::make_clamped_nonuniform<double>;
 
 %template(ClampedNonUniformConstant) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::CONSTANT>;
 %template() types::ClampedNonUniformConstant<double>;
-%template(clamped_nonuniform_constant) factory::clamped_nonuniform_constant<double>;
+%template(clamped_nonuniform_constant) factory::make_clamped_nonuniform_constant<double>;
 
 %template(PeriodicUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::PERIODIC, Extrapolation::PERIODIC>;
 %template() types::PeriodicUniform<double>;
-%template(periodic_uniform) factory::periodic_uniform<double>;
+%template(periodic_uniform) factory::make_periodic_uniform<double>;
 
 %template(PeriodicNonUniform) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::PERIODIC, Extrapolation::PERIODIC>;
 %template() types::PeriodicNonUniform<double>;
-%template(periodic_nonuniform) factory::periodic_nonuniform<double>;
+%template(periodic_nonuniform) factory::make_periodic_nonuniform<double>;

--- a/bindings/BSplineX.i
+++ b/bindings/BSplineX.i
@@ -2,6 +2,7 @@
 
 // Injected C++ code
 %{
+#include "BSplineX/bsplinex.hpp"
 #include "BSplineX/defines.hpp"
 #include "BSplineX/types.hpp"
 #include "BSplineX/bspline/bspline.hpp"
@@ -18,6 +19,7 @@ using namespace bsplinex;
 %template() std::pair<double, double>;
 %template() std::vector<double>;
 
+%include "BSplineX/bsplinex.hpp"
 %include "BSplineX/defines.hpp"
 %include "BSplineX/types.hpp"
 %include "BSplineX/bspline/bspline.hpp"
@@ -41,41 +43,41 @@ using namespace bsplinex;
 %template() std::vector<lsq::Condition<double>>;
 
 %template(OpenUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::OPEN, Extrapolation::NONE>;
-%template() types::OpenUniform<double>;
-%template(open_uniform) factory::make_open_uniform<double>;
+%template() OpenUniform<double>;
+%template(open_uniform) make_open_uniform<double>;
 
 %template(OpenUniformConstant) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::OPEN, Extrapolation::CONSTANT>;
-%template() types::OpenUniformConstant<double>;
-%template(open_uniform_constant) factory::make_open_uniform_constant<double>;
+%template() OpenUniformConstant<double>;
+%template(open_uniform_constant) make_open_uniform_constant<double>;
 
 %template(OpenNonUniform) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::OPEN, Extrapolation::NONE>;
-%template() types::OpenNonUniform<double>;
-%template(open_nonuniform) factory::make_open_nonuniform<double>;
+%template() OpenNonUniform<double>;
+%template(open_nonuniform) make_open_nonuniform<double>;
 
 %template(OpenNonUniformConstant) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::OPEN, Extrapolation::CONSTANT>;
-%template() types::OpenNonUniformConstant<double>;
-%template(open_nonuniform_constant) factory::make_open_nonuniform_constant<double>;
+%template() OpenNonUniformConstant<double>;
+%template(open_nonuniform_constant) make_open_nonuniform_constant<double>;
 
 %template(ClampedUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::NONE>;
-%template() types::ClampedUniform<double>;
-%template(clamped_uniform) factory::make_clamped_uniform<double>;
+%template() ClampedUniform<double>;
+%template(clamped_uniform) make_clamped_uniform<double>;
 
 %template(ClampedUniformConstant) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::CONSTANT>;
-%template() types::ClampedUniformConstant<double>;
-%template(clamped_uniform_constant) factory::make_clamped_uniform_constant<double>;
+%template() ClampedUniformConstant<double>;
+%template(clamped_uniform_constant) make_clamped_uniform_constant<double>;
 
 %template(ClampedNonUniform) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::NONE>;
-%template() types::ClampedNonUniform<double>;
-%template(clamped_nonuniform) factory::make_clamped_nonuniform<double>;
+%template() ClampedNonUniform<double>;
+%template(clamped_nonuniform) make_clamped_nonuniform<double>;
 
 %template(ClampedNonUniformConstant) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::CONSTANT>;
-%template() types::ClampedNonUniformConstant<double>;
-%template(clamped_nonuniform_constant) factory::make_clamped_nonuniform_constant<double>;
+%template() ClampedNonUniformConstant<double>;
+%template(clamped_nonuniform_constant) make_clamped_nonuniform_constant<double>;
 
 %template(PeriodicUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::PERIODIC, Extrapolation::PERIODIC>;
-%template() types::PeriodicUniform<double>;
-%template(periodic_uniform) factory::make_periodic_uniform<double>;
+%template() PeriodicUniform<double>;
+%template(periodic_uniform) make_periodic_uniform<double>;
 
 %template(PeriodicNonUniform) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::PERIODIC, Extrapolation::PERIODIC>;
-%template() types::PeriodicNonUniform<double>;
-%template(periodic_nonuniform) factory::make_periodic_nonuniform<double>;
+%template() PeriodicNonUniform<double>;
+%template(periodic_nonuniform) make_periodic_nonuniform<double>;

--- a/bindings/BSplineX.i
+++ b/bindings/BSplineX.i
@@ -40,13 +40,6 @@ using namespace bsplinex;
 %template(Condition) lsq::Condition<double>;
 %template() std::vector<lsq::Condition<double>>;
 
-//  ██████╗ ██████╗ ███████╗███╗   ██╗
-// ██╔═══██╗██╔══██╗██╔════╝████╗  ██║
-// ██║   ██║██████╔╝█████╗  ██╔██╗ ██║
-// ██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║
-// ╚██████╔╝██║     ███████╗██║ ╚████║
-//  ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝
-
 %template(OpenUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::OPEN, Extrapolation::NONE>;
 %template() types::OpenUniform<double>;
 %template(open_uniform) factory::open_uniform<double>;
@@ -63,13 +56,6 @@ using namespace bsplinex;
 %template() types::OpenNonUniformConstant<double>;
 %template(open_nonuniform_constant) factory::open_nonuniform_constant<double>;
 
-//  ██████╗██╗      █████╗ ███╗   ███╗██████╗ ███████╗██████╗
-// ██╔════╝██║     ██╔══██╗████╗ ████║██╔══██╗██╔════╝██╔══██╗
-// ██║     ██║     ███████║██╔████╔██║██████╔╝█████╗  ██║  ██║
-// ██║     ██║     ██╔══██║██║╚██╔╝██║██╔═══╝ ██╔══╝  ██║  ██║
-// ╚██████╗███████╗██║  ██║██║ ╚═╝ ██║██║     ███████╗██████╔╝
-// ╚═════╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝     ╚══════╝╚═════╝
-
 %template(ClampedUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::NONE>;
 %template() types::ClampedUniform<double>;
 %template(clamped_uniform) factory::clamped_uniform<double>;
@@ -85,13 +71,6 @@ using namespace bsplinex;
 %template(ClampedNonUniformConstant) bspline::BSpline<double, Curve::NON_UNIFORM, BoundaryCondition::CLAMPED, Extrapolation::CONSTANT>;
 %template() types::ClampedNonUniformConstant<double>;
 %template(clamped_nonuniform_constant) factory::clamped_nonuniform_constant<double>;
-
-// ██████╗ ███████╗██████╗ ██╗ ██████╗ ██████╗ ██╗ ██████╗
-// ██╔══██╗██╔════╝██╔══██╗██║██╔═══██╗██╔══██╗██║██╔════╝
-// ██████╔╝█████╗  ██████╔╝██║██║   ██║██║  ██║██║██║
-// ██╔═══╝ ██╔══╝  ██╔══██╗██║██║   ██║██║  ██║██║██║
-// ██║     ███████╗██║  ██║██║╚██████╔╝██████╔╝██║╚██████╗
-// ╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝ ╚═════╝ ╚═════╝ ╚═╝ ╚═════╝
 
 %template(PeriodicUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::PERIODIC, Extrapolation::PERIODIC>;
 %template() types::PeriodicUniform<double>;

--- a/bindings/BSplineX.i
+++ b/bindings/BSplineX.i
@@ -6,7 +6,6 @@
 #include "BSplineX/types.hpp"
 #include "BSplineX/bspline/bspline.hpp"
 #include "BSplineX/bspline/bspline_types.hpp"
-#include "BSplineX/bspline/bspline_factory.hpp"
 #include "BSplineX/bspline/bspline_factory_open.hpp"
 #include "BSplineX/bspline/bspline_factory_clamped.hpp"
 #include "BSplineX/bspline/bspline_factory_periodic.hpp"
@@ -22,12 +21,11 @@ using namespace bsplinex;
 %include "BSplineX/defines.hpp"
 %include "BSplineX/types.hpp"
 %include "BSplineX/bspline/bspline.hpp"
-%include "BSplineX/bspline/bspline_factory.hpp"
+%include "BSplineX/bspline/bspline_types.hpp"
 %include "BSplineX/bspline/bspline_factory_open.hpp"
 %include "BSplineX/bspline/bspline_factory_clamped.hpp"
 %include "BSplineX/bspline/bspline_factory_periodic.hpp"
 %include "BSplineX/bspline/bspline_lsq.hpp"
-%include "BSplineX/bspline/bspline_types.hpp"
 %include "exception.i"
 using namespace bsplinex;
 

--- a/bindings/BSplineX.i
+++ b/bindings/BSplineX.i
@@ -39,8 +39,8 @@ using namespace bsplinex;
   }
 }
 
-%template(Condition) lsq::Condition<double>;
-%template() std::vector<lsq::Condition<double>>;
+%template(Condition) InterpolantCondition<double>;
+%template() std::vector<InterpolantCondition<double>>;
 
 %template(OpenUniform) bspline::BSpline<double, Curve::UNIFORM, BoundaryCondition::OPEN, Extrapolation::NONE>;
 %template() OpenUniform<double>;

--- a/cmake/test_cmake_inclusion/test.cpp
+++ b/cmake/test_cmake_inclusion/test.cpp
@@ -3,9 +3,10 @@
 
 int main()
 {
-  auto bspline = bsplinex::factory::periodic_nonuniform(3, {0, 1, 2, 3, 4});
+  auto bspline = bsplinex::periodic_nonuniform(3, {0, 1, 2, 3, 4});
 
-  std::cout << bspline.evaluate(3.0) << std::endl;
+  constexpr double x{3.0};
+  std::cout << bspline.evaluate(x) << "\n";
 
   return 0;
 }

--- a/cmake/test_cmake_inclusion/test.cpp
+++ b/cmake/test_cmake_inclusion/test.cpp
@@ -3,7 +3,7 @@
 
 int main()
 {
-  auto bspline = bsplinex::periodic_nonuniform(3, {0, 1, 2, 3, 4});
+  auto bspline = bsplinex::make_periodic_nonuniform(3, {0, 1, 2, 3, 4});
 
   constexpr double x{3.0};
   std::cout << bspline.evaluate(x) << "\n";

--- a/examples/ex_evaluate.cpp
+++ b/examples/ex_evaluate.cpp
@@ -10,7 +10,7 @@ int main()
   std::vector<double> const knots{0.1, 1.3, 2.2, 2.2, 4.9, 6.3, 6.3, 6.3, 13.2};
   std::vector<double> const control_points{0.1, 1.3, 2.2, 4.9, 13.2};
 
-  auto bspline = bsplinex::factory::open_nonuniform(degree, knots, control_points);
+  auto bspline = bsplinex::open_nonuniform(degree, knots, control_points);
 
   // evaluate the curve at some points
   std::vector<double> const eval_x{3.0, 3.4, 5.1, 6.2};

--- a/examples/ex_evaluate.cpp
+++ b/examples/ex_evaluate.cpp
@@ -10,7 +10,7 @@ int main()
   std::vector<double> const knots{0.1, 1.3, 2.2, 2.2, 4.9, 6.3, 6.3, 6.3, 13.2};
   std::vector<double> const control_points{0.1, 1.3, 2.2, 4.9, 13.2};
 
-  auto bspline = bsplinex::open_nonuniform(degree, knots, control_points);
+  auto bspline = bsplinex::make_open_nonuniform(degree, knots, control_points);
 
   // evaluate the curve at some points
   std::vector<double> const eval_x{3.0, 3.4, 5.1, 6.2};

--- a/examples/ex_fit.cpp
+++ b/examples/ex_fit.cpp
@@ -16,7 +16,7 @@ int main()
   constexpr double knots_end{12.0};
   constexpr size_t num_knots{12};
 
-  auto bspline = bsplinex::factory::periodic_uniform(degree, knots_begin, knots_end, num_knots);
+  auto bspline = bsplinex::periodic_uniform(degree, knots_begin, knots_end, num_knots);
 
   // fit the curve to the points
   bspline.fit(x_fit, y_fit);

--- a/examples/ex_fit.cpp
+++ b/examples/ex_fit.cpp
@@ -16,7 +16,7 @@ int main()
   constexpr double knots_end{12.0};
   constexpr size_t num_knots{12};
 
-  auto bspline = bsplinex::periodic_uniform(degree, knots_begin, knots_end, num_knots);
+  auto bspline = bsplinex::make_periodic_uniform(degree, knots_begin, knots_end, num_knots);
 
   // fit the curve to the points
   bspline.fit(x_fit, y_fit);

--- a/examples/ex_interpolate.cpp
+++ b/examples/ex_interpolate.cpp
@@ -16,7 +16,7 @@ int main()
 
   constexpr size_t degree{2};
 
-  auto bspline = bsplinex::open_nonuniform(degree);
+  auto bspline = bsplinex::make_open_nonuniform(degree);
 
   // interpolate the curve to the points
   bspline.interpolate(x_interp, y_interp, {{cond_x, cond_y, cond_d}});

--- a/examples/ex_interpolate.cpp
+++ b/examples/ex_interpolate.cpp
@@ -16,7 +16,7 @@ int main()
 
   constexpr size_t degree{2};
 
-  auto bspline = bsplinex::factory::open_nonuniform(degree);
+  auto bspline = bsplinex::open_nonuniform(degree);
 
   // interpolate the curve to the points
   bspline.interpolate(x_interp, y_interp, {{cond_x, cond_y, cond_d}});

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -341,7 +341,7 @@ public:
     else
     {
       static_assert(
-          dependent_false<BC>::value, "Unknown boundary condition, you should never get here!"
+          dependent_false<T>::value, "Unknown boundary condition, you should never get here!"
       );
     }
 

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -341,7 +341,8 @@ public:
     else
     {
       static_assert(
-          dependent_false<BoundaryCondition>::value, "Unknown boundary condition, you should never get here!"
+          dependent_false<decltype(BC)>::value,
+          "Unknown boundary condition, you should never get here!"
       );
     }
 

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -286,7 +286,7 @@ public:
   void interpolate(
       std::vector<T> const &x,
       std::vector<T> const &y,
-      std::vector<lsq::Condition<T>> const &additional_conditions
+      std::vector<lsq::InterpolantCondition<T>> const &additional_conditions
   )
   {
     releaseassert(x.size() == y.size(), "x and y must have the same size");

--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -341,7 +341,7 @@ public:
     else
     {
       static_assert(
-          dependent_false<T>::value, "Unknown boundary condition, you should never get here!"
+          dependent_false<BoundaryCondition>::value, "Unknown boundary condition, you should never get here!"
       );
     }
 

--- a/include/BSplineX/bspline/bspline_factory.hpp
+++ b/include/BSplineX/bspline/bspline_factory.hpp
@@ -1,9 +1,0 @@
-#ifndef BSPLINEX_BSPLINE_BSPLINE_FACTORY_HPP
-#define BSPLINEX_BSPLINE_BSPLINE_FACTORY_HPP
-
-// BSplineX
-#include "BSplineX/bspline/bspline_factory_clamped.hpp"
-#include "BSplineX/bspline/bspline_factory_open.hpp"
-#include "BSplineX/bspline/bspline_factory_periodic.hpp"
-
-#endif

--- a/include/BSplineX/bspline/bspline_factory_clamped.hpp
+++ b/include/BSplineX/bspline/bspline_factory_clamped.hpp
@@ -32,8 +32,9 @@ using namespace constants;
  * @return A clamped uniform BSpline.
  */
 template <typename T = double>
-types::ClampedUniform<T>
-clamped_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points)
+types::ClampedUniform<T> make_clamped_uniform(
+    size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
+)
 {
   return types::ClampedUniform<T>{
       knots::Data<T, types::ClampedUniform<T>::curve_type>{begin, end, num_elems},
@@ -57,9 +58,11 @@ clamped_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> 
  * @return A clamped uniform BSpline.
  */
 template <typename T = double>
-types::ClampedUniform<T> clamped_uniform(size_t degree, T begin, T end, size_t num_elems)
+types::ClampedUniform<T> make_clamped_uniform(size_t degree, T begin, T end, size_t num_elems)
 {
-  return clamped_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1));
+  return make_clamped_uniform<T>(
+      degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1)
+  );
 }
 
 /**
@@ -73,12 +76,14 @@ types::ClampedUniform<T> clamped_uniform(size_t degree, T begin, T end, size_t n
  * @return A clamped uniform BSpline.
  */
 template <typename T = double>
-types::ClampedUniform<T> clamped_uniform(size_t degree)
+types::ClampedUniform<T> make_clamped_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
   constexpr size_t num_elems{2};
-  return clamped_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1));
+  return make_clamped_uniform<T>(
+      degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1)
+  );
 }
 
 /**
@@ -98,7 +103,7 @@ types::ClampedUniform<T> clamped_uniform(size_t degree)
  * @return A clamped uniform constant BSpline.
  */
 template <typename T = double>
-types::ClampedUniformConstant<T> clamped_uniform_constant(
+types::ClampedUniformConstant<T> make_clamped_uniform_constant(
     size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
 )
 {
@@ -125,9 +130,9 @@ types::ClampedUniformConstant<T> clamped_uniform_constant(
  */
 template <typename T = double>
 types::ClampedUniformConstant<T>
-clamped_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
+make_clamped_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
 {
-  return clamped_uniform_constant<T>(
+  return make_clamped_uniform_constant<T>(
       degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1)
   );
 }
@@ -143,12 +148,12 @@ clamped_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
  * @return A clamped uniform constant BSpline.
  */
 template <typename T = double>
-types::ClampedUniformConstant<T> clamped_uniform_constant(size_t degree)
+types::ClampedUniformConstant<T> make_clamped_uniform_constant(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
   constexpr size_t num_elems{2};
-  return clamped_uniform_constant<T>(
+  return make_clamped_uniform_constant<T>(
       degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1)
   );
 }
@@ -168,8 +173,9 @@ types::ClampedUniformConstant<T> clamped_uniform_constant(size_t degree)
  * @return A clamped non-uniform BSpline.
  */
 template <typename T = double>
-types::ClampedNonUniform<T>
-clamped_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
+types::ClampedNonUniform<T> make_clamped_nonuniform(
+    size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points
+)
 {
   return types::ClampedNonUniform<T>{
       knots::Data<T, types::ClampedNonUniform<T>::curve_type>{knots},
@@ -191,9 +197,9 @@ clamped_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> co
  * @return A clamped non-uniform BSpline.
  */
 template <typename T = double>
-types::ClampedNonUniform<T> clamped_nonuniform(size_t degree, std::vector<T> const &knots)
+types::ClampedNonUniform<T> make_clamped_nonuniform(size_t degree, std::vector<T> const &knots)
 {
-  return clamped_nonuniform<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
+  return make_clamped_nonuniform<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
 }
 
 /**
@@ -207,10 +213,10 @@ types::ClampedNonUniform<T> clamped_nonuniform(size_t degree, std::vector<T> con
  * @return A clamped non-uniform BSpline.
  */
 template <typename T = double>
-types::ClampedNonUniform<T> clamped_nonuniform(size_t degree)
+types::ClampedNonUniform<T> make_clamped_nonuniform(size_t degree)
 {
   std::vector<T> const knots(2);
-  return clamped_nonuniform<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
+  return make_clamped_nonuniform<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
 }
 
 /**
@@ -228,7 +234,7 @@ types::ClampedNonUniform<T> clamped_nonuniform(size_t degree)
  * @return A clamped non-uniform constant BSpline.
  */
 template <typename T = double>
-types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(
+types::ClampedNonUniformConstant<T> make_clamped_nonuniform_constant(
     size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points
 )
 {
@@ -253,9 +259,11 @@ types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(
  */
 template <typename T = double>
 types::ClampedNonUniformConstant<T>
-clamped_nonuniform_constant(size_t degree, std::vector<T> const &knots)
+make_clamped_nonuniform_constant(size_t degree, std::vector<T> const &knots)
 {
-  return clamped_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
+  return make_clamped_nonuniform_constant<T>(
+      degree, knots, std::vector<T>(knots.size() + degree - 1)
+  );
 }
 
 /**
@@ -269,10 +277,12 @@ clamped_nonuniform_constant(size_t degree, std::vector<T> const &knots)
  * @return A clamped non-uniform constant BSpline.
  */
 template <typename T = double>
-types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(size_t degree)
+types::ClampedNonUniformConstant<T> make_clamped_nonuniform_constant(size_t degree)
 {
   std::vector<T> const knots(2);
-  return clamped_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
+  return make_clamped_nonuniform_constant<T>(
+      degree, knots, std::vector<T>(knots.size() + degree - 1)
+  );
 }
 
 } // namespace bsplinex::factory

--- a/include/BSplineX/bspline/bspline_factory_clamped.hpp
+++ b/include/BSplineX/bspline/bspline_factory_clamped.hpp
@@ -32,7 +32,7 @@ using namespace constants;
  * @return A clamped uniform BSpline.
  */
 template <typename T = double>
-inline types::ClampedUniform<T>
+types::ClampedUniform<T>
 clamped_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points)
 {
   return types::ClampedUniform<T>{
@@ -57,7 +57,7 @@ clamped_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> 
  * @return A clamped uniform BSpline.
  */
 template <typename T = double>
-inline types::ClampedUniform<T> clamped_uniform(size_t degree, T begin, T end, size_t num_elems)
+types::ClampedUniform<T> clamped_uniform(size_t degree, T begin, T end, size_t num_elems)
 {
   return clamped_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems + degree - 1));
 }
@@ -73,7 +73,7 @@ inline types::ClampedUniform<T> clamped_uniform(size_t degree, T begin, T end, s
  * @return A clamped uniform BSpline.
  */
 template <typename T = double>
-inline types::ClampedUniform<T> clamped_uniform(size_t degree)
+types::ClampedUniform<T> clamped_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
@@ -98,7 +98,7 @@ inline types::ClampedUniform<T> clamped_uniform(size_t degree)
  * @return A clamped uniform constant BSpline.
  */
 template <typename T = double>
-inline types::ClampedUniformConstant<T> clamped_uniform_constant(
+types::ClampedUniformConstant<T> clamped_uniform_constant(
     size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
 )
 {
@@ -124,7 +124,7 @@ inline types::ClampedUniformConstant<T> clamped_uniform_constant(
  * @return A clamped uniform constant BSpline.
  */
 template <typename T = double>
-inline types::ClampedUniformConstant<T>
+types::ClampedUniformConstant<T>
 clamped_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
 {
   return clamped_uniform_constant<T>(
@@ -143,7 +143,7 @@ clamped_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
  * @return A clamped uniform constant BSpline.
  */
 template <typename T = double>
-inline types::ClampedUniformConstant<T> clamped_uniform_constant(size_t degree)
+types::ClampedUniformConstant<T> clamped_uniform_constant(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
@@ -168,7 +168,7 @@ inline types::ClampedUniformConstant<T> clamped_uniform_constant(size_t degree)
  * @return A clamped non-uniform BSpline.
  */
 template <typename T = double>
-inline types::ClampedNonUniform<T>
+types::ClampedNonUniform<T>
 clamped_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
 {
   return types::ClampedNonUniform<T>{
@@ -191,7 +191,7 @@ clamped_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> co
  * @return A clamped non-uniform BSpline.
  */
 template <typename T = double>
-inline types::ClampedNonUniform<T> clamped_nonuniform(size_t degree, std::vector<T> const &knots)
+types::ClampedNonUniform<T> clamped_nonuniform(size_t degree, std::vector<T> const &knots)
 {
   return clamped_nonuniform<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
 }
@@ -207,7 +207,7 @@ inline types::ClampedNonUniform<T> clamped_nonuniform(size_t degree, std::vector
  * @return A clamped non-uniform BSpline.
  */
 template <typename T = double>
-inline types::ClampedNonUniform<T> clamped_nonuniform(size_t degree)
+types::ClampedNonUniform<T> clamped_nonuniform(size_t degree)
 {
   std::vector<T> const knots(2);
   return clamped_nonuniform<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
@@ -228,7 +228,7 @@ inline types::ClampedNonUniform<T> clamped_nonuniform(size_t degree)
  * @return A clamped non-uniform constant BSpline.
  */
 template <typename T = double>
-inline types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(
+types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(
     size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points
 )
 {
@@ -252,7 +252,7 @@ inline types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(
  * @return A clamped non-uniform constant BSpline.
  */
 template <typename T = double>
-inline types::ClampedNonUniformConstant<T>
+types::ClampedNonUniformConstant<T>
 clamped_nonuniform_constant(size_t degree, std::vector<T> const &knots)
 {
   return clamped_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));
@@ -269,7 +269,7 @@ clamped_nonuniform_constant(size_t degree, std::vector<T> const &knots)
  * @return A clamped non-uniform constant BSpline.
  */
 template <typename T = double>
-inline types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(size_t degree)
+types::ClampedNonUniformConstant<T> clamped_nonuniform_constant(size_t degree)
 {
   std::vector<T> const knots(2);
   return clamped_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() + degree - 1));

--- a/include/BSplineX/bspline/bspline_factory_open.hpp
+++ b/include/BSplineX/bspline/bspline_factory_open.hpp
@@ -33,7 +33,7 @@ using namespace constants;
  * @return A open uniform BSpline.
  */
 template <typename T = double>
-inline types::OpenUniform<T>
+types::OpenUniform<T>
 open_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points)
 {
   return types::OpenUniform<T>{
@@ -59,7 +59,7 @@ open_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> con
  * @return A open uniform BSpline.
  */
 template <typename T = double>
-inline types::OpenUniform<T> open_uniform(size_t degree, T begin, T end, size_t num_elems)
+types::OpenUniform<T> open_uniform(size_t degree, T begin, T end, size_t num_elems)
 {
   return open_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1));
 }
@@ -75,7 +75,7 @@ inline types::OpenUniform<T> open_uniform(size_t degree, T begin, T end, size_t 
  * @return A open uniform BSpline.
  */
 template <typename T = double>
-inline types::OpenUniform<T> open_uniform(size_t degree)
+types::OpenUniform<T> open_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
@@ -101,7 +101,7 @@ inline types::OpenUniform<T> open_uniform(size_t degree)
  * @return A open uniform constant BSpline.
  */
 template <typename T = double>
-inline types::OpenUniformConstant<T> open_uniform_constant(
+types::OpenUniformConstant<T> open_uniform_constant(
     size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
 )
 {
@@ -128,8 +128,7 @@ inline types::OpenUniformConstant<T> open_uniform_constant(
  * @return A open uniform constant BSpline.
  */
 template <typename T = double>
-inline types::OpenUniformConstant<T>
-open_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
+types::OpenUniformConstant<T> open_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
 {
   return open_uniform_constant<T>(
       degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1)
@@ -147,7 +146,7 @@ open_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
  * @return A open uniform constant BSpline.
  */
 template <typename T = double>
-inline types::OpenUniformConstant<T> open_uniform_constant(size_t degree)
+types::OpenUniformConstant<T> open_uniform_constant(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
@@ -172,7 +171,7 @@ inline types::OpenUniformConstant<T> open_uniform_constant(size_t degree)
  * @return A open non-uniform BSpline.
  */
 template <typename T = double>
-inline types::OpenNonUniform<T>
+types::OpenNonUniform<T>
 open_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
 {
   return types::OpenNonUniform<T>{
@@ -195,7 +194,7 @@ open_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const
  * @return A open non-uniform BSpline.
  */
 template <typename T = double>
-inline types::OpenNonUniform<T> open_nonuniform(size_t degree, std::vector<T> const &knots)
+types::OpenNonUniform<T> open_nonuniform(size_t degree, std::vector<T> const &knots)
 {
   return open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
@@ -211,7 +210,7 @@ inline types::OpenNonUniform<T> open_nonuniform(size_t degree, std::vector<T> co
  * @return A open non-uniform BSpline.
  */
 template <typename T = double>
-inline types::OpenNonUniform<T> open_nonuniform(size_t degree)
+types::OpenNonUniform<T> open_nonuniform(size_t degree)
 {
   std::vector<T> const knots(1 + 2 * degree);
   return open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
@@ -232,7 +231,7 @@ inline types::OpenNonUniform<T> open_nonuniform(size_t degree)
  * @return A open non-uniform constant BSpline.
  */
 template <typename T = double>
-inline types::OpenNonUniformConstant<T> open_nonuniform_constant(
+types::OpenNonUniformConstant<T> open_nonuniform_constant(
     size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points
 )
 {
@@ -256,7 +255,7 @@ inline types::OpenNonUniformConstant<T> open_nonuniform_constant(
  * @return A open non-uniform constant BSpline.
  */
 template <typename T = double>
-inline types::OpenNonUniformConstant<T>
+types::OpenNonUniformConstant<T>
 open_nonuniform_constant(size_t degree, std::vector<T> const &knots)
 {
   return open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
@@ -273,7 +272,7 @@ open_nonuniform_constant(size_t degree, std::vector<T> const &knots)
  * @return A open non-uniform constant BSpline.
  */
 template <typename T = double>
-inline types::OpenNonUniformConstant<T> open_nonuniform_constant(size_t degree)
+types::OpenNonUniformConstant<T> open_nonuniform_constant(size_t degree)
 {
   std::vector<T> const knots(1 + 2 * degree);
   return open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));

--- a/include/BSplineX/bspline/bspline_factory_open.hpp
+++ b/include/BSplineX/bspline/bspline_factory_open.hpp
@@ -79,7 +79,7 @@ types::OpenUniform<T> open_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
-  size_t const num_elems{1 + 2 * degree};
+  size_t const num_elems{1 + (2 * degree)};
   return open_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1));
 }
 
@@ -150,7 +150,7 @@ types::OpenUniformConstant<T> open_uniform_constant(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
-  size_t const num_elems{1 + 2 * degree};
+  size_t const num_elems{1 + (2 * degree)};
   return open_uniform_constant<T>(
       degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1)
   );
@@ -212,7 +212,7 @@ types::OpenNonUniform<T> open_nonuniform(size_t degree, std::vector<T> const &kn
 template <typename T = double>
 types::OpenNonUniform<T> open_nonuniform(size_t degree)
 {
-  std::vector<T> const knots(1 + 2 * degree);
+  std::vector<T> const knots(1 + (2 * degree));
   return open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
 
@@ -274,7 +274,7 @@ open_nonuniform_constant(size_t degree, std::vector<T> const &knots)
 template <typename T = double>
 types::OpenNonUniformConstant<T> open_nonuniform_constant(size_t degree)
 {
-  std::vector<T> const knots(1 + 2 * degree);
+  std::vector<T> const knots(1 + (2 * degree));
   return open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
 

--- a/include/BSplineX/bspline/bspline_factory_open.hpp
+++ b/include/BSplineX/bspline/bspline_factory_open.hpp
@@ -33,8 +33,9 @@ using namespace constants;
  * @return A open uniform BSpline.
  */
 template <typename T = double>
-types::OpenUniform<T>
-open_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points)
+types::OpenUniform<T> make_open_uniform(
+    size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
+)
 {
   return types::OpenUniform<T>{
       knots::Data<T, types::OpenUniform<T>::curve_type>{begin, end, num_elems},
@@ -59,9 +60,11 @@ open_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> con
  * @return A open uniform BSpline.
  */
 template <typename T = double>
-types::OpenUniform<T> open_uniform(size_t degree, T begin, T end, size_t num_elems)
+types::OpenUniform<T> make_open_uniform(size_t degree, T begin, T end, size_t num_elems)
 {
-  return open_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1));
+  return make_open_uniform<T>(
+      degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1)
+  );
 }
 
 /**
@@ -75,12 +78,14 @@ types::OpenUniform<T> open_uniform(size_t degree, T begin, T end, size_t num_ele
  * @return A open uniform BSpline.
  */
 template <typename T = double>
-types::OpenUniform<T> open_uniform(size_t degree)
+types::OpenUniform<T> make_open_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
   size_t const num_elems{1 + (2 * degree)};
-  return open_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1));
+  return make_open_uniform<T>(
+      degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1)
+  );
 }
 
 /**
@@ -101,7 +106,7 @@ types::OpenUniform<T> open_uniform(size_t degree)
  * @return A open uniform constant BSpline.
  */
 template <typename T = double>
-types::OpenUniformConstant<T> open_uniform_constant(
+types::OpenUniformConstant<T> make_open_uniform_constant(
     size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
 )
 {
@@ -128,9 +133,10 @@ types::OpenUniformConstant<T> open_uniform_constant(
  * @return A open uniform constant BSpline.
  */
 template <typename T = double>
-types::OpenUniformConstant<T> open_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
+types::OpenUniformConstant<T>
+make_open_uniform_constant(size_t degree, T begin, T end, size_t num_elems)
 {
-  return open_uniform_constant<T>(
+  return make_open_uniform_constant<T>(
       degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1)
   );
 }
@@ -146,12 +152,12 @@ types::OpenUniformConstant<T> open_uniform_constant(size_t degree, T begin, T en
  * @return A open uniform constant BSpline.
  */
 template <typename T = double>
-types::OpenUniformConstant<T> open_uniform_constant(size_t degree)
+types::OpenUniformConstant<T> make_open_uniform_constant(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
   size_t const num_elems{1 + (2 * degree)};
-  return open_uniform_constant<T>(
+  return make_open_uniform_constant<T>(
       degree, begin, end, num_elems, std::vector<T>(num_elems - degree - 1)
   );
 }
@@ -172,7 +178,7 @@ types::OpenUniformConstant<T> open_uniform_constant(size_t degree)
  */
 template <typename T = double>
 types::OpenNonUniform<T>
-open_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
+make_open_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
 {
   return types::OpenNonUniform<T>{
       knots::Data<T, types::OpenNonUniform<T>::curve_type>{knots},
@@ -194,9 +200,9 @@ open_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const
  * @return A open non-uniform BSpline.
  */
 template <typename T = double>
-types::OpenNonUniform<T> open_nonuniform(size_t degree, std::vector<T> const &knots)
+types::OpenNonUniform<T> make_open_nonuniform(size_t degree, std::vector<T> const &knots)
 {
-  return open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
+  return make_open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
 
 /**
@@ -210,10 +216,10 @@ types::OpenNonUniform<T> open_nonuniform(size_t degree, std::vector<T> const &kn
  * @return A open non-uniform BSpline.
  */
 template <typename T = double>
-types::OpenNonUniform<T> open_nonuniform(size_t degree)
+types::OpenNonUniform<T> make_open_nonuniform(size_t degree)
 {
   std::vector<T> const knots(1 + (2 * degree));
-  return open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
+  return make_open_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
 
 /**
@@ -231,7 +237,7 @@ types::OpenNonUniform<T> open_nonuniform(size_t degree)
  * @return A open non-uniform constant BSpline.
  */
 template <typename T = double>
-types::OpenNonUniformConstant<T> open_nonuniform_constant(
+types::OpenNonUniformConstant<T> make_open_nonuniform_constant(
     size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points
 )
 {
@@ -256,9 +262,9 @@ types::OpenNonUniformConstant<T> open_nonuniform_constant(
  */
 template <typename T = double>
 types::OpenNonUniformConstant<T>
-open_nonuniform_constant(size_t degree, std::vector<T> const &knots)
+make_open_nonuniform_constant(size_t degree, std::vector<T> const &knots)
 {
-  return open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
+  return make_open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
 
 /**
@@ -272,10 +278,10 @@ open_nonuniform_constant(size_t degree, std::vector<T> const &knots)
  * @return A open non-uniform constant BSpline.
  */
 template <typename T = double>
-types::OpenNonUniformConstant<T> open_nonuniform_constant(size_t degree)
+types::OpenNonUniformConstant<T> make_open_nonuniform_constant(size_t degree)
 {
   std::vector<T> const knots(1 + (2 * degree));
-  return open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
+  return make_open_nonuniform_constant<T>(degree, knots, std::vector<T>(knots.size() - degree - 1));
 }
 
 } // namespace bsplinex::factory

--- a/include/BSplineX/bspline/bspline_factory_periodic.hpp
+++ b/include/BSplineX/bspline/bspline_factory_periodic.hpp
@@ -33,8 +33,9 @@ using namespace constants;
  * @return A periodic uniform BSpline.
  */
 template <typename T = double>
-types::PeriodicUniform<T>
-periodic_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points)
+types::PeriodicUniform<T> make_periodic_uniform(
+    size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points
+)
 {
   return types::PeriodicUniform<T>{
       knots::Data<T, types::PeriodicUniform<T>::curve_type>{begin, end, num_elems},
@@ -58,9 +59,9 @@ periodic_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T>
  * @return A periodic uniform BSpline.
  */
 template <typename T = double>
-types::PeriodicUniform<T> periodic_uniform(size_t degree, T begin, T end, size_t num_elems)
+types::PeriodicUniform<T> make_periodic_uniform(size_t degree, T begin, T end, size_t num_elems)
 {
-  return periodic_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - 1));
+  return make_periodic_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - 1));
 }
 
 /**
@@ -74,12 +75,12 @@ types::PeriodicUniform<T> periodic_uniform(size_t degree, T begin, T end, size_t
  * @return A periodic uniform BSpline.
  */
 template <typename T = double>
-types::PeriodicUniform<T> periodic_uniform(size_t degree)
+types::PeriodicUniform<T> make_periodic_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
   size_t const num_elems{2 * degree};
-  return periodic_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - 1));
+  return make_periodic_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - 1));
 }
 
 /**
@@ -98,8 +99,9 @@ types::PeriodicUniform<T> periodic_uniform(size_t degree)
  * @return A periodic non-uniform BSpline.
  */
 template <typename T = double>
-types::PeriodicNonUniform<T>
-periodic_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
+types::PeriodicNonUniform<T> make_periodic_nonuniform(
+    size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points
+)
 {
   return types::PeriodicNonUniform<T>{
       knots::Data<T, types::PeriodicNonUniform<T>::curve_type>{knots},
@@ -121,9 +123,9 @@ periodic_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> c
  * @return A periodic non-uniform BSpline.
  */
 template <typename T = double>
-types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree, std::vector<T> const &knots)
+types::PeriodicNonUniform<T> make_periodic_nonuniform(size_t degree, std::vector<T> const &knots)
 {
-  return periodic_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - 1));
+  return make_periodic_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - 1));
 }
 
 /**
@@ -137,10 +139,10 @@ types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree, std::vector<T> c
  * @return A periodic non-uniform BSpline.
  */
 template <typename T = double>
-types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree)
+types::PeriodicNonUniform<T> make_periodic_nonuniform(size_t degree)
 {
   std::vector<T> const knots(2 * degree);
-  return periodic_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - 1));
+  return make_periodic_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - 1));
 }
 
 } // namespace bsplinex::factory

--- a/include/BSplineX/bspline/bspline_factory_periodic.hpp
+++ b/include/BSplineX/bspline/bspline_factory_periodic.hpp
@@ -33,7 +33,7 @@ using namespace constants;
  * @return A periodic uniform BSpline.
  */
 template <typename T = double>
-inline types::PeriodicUniform<T>
+types::PeriodicUniform<T>
 periodic_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T> const &ctrl_points)
 {
   return types::PeriodicUniform<T>{
@@ -58,7 +58,7 @@ periodic_uniform(size_t degree, T begin, T end, size_t num_elems, std::vector<T>
  * @return A periodic uniform BSpline.
  */
 template <typename T = double>
-inline types::PeriodicUniform<T> periodic_uniform(size_t degree, T begin, T end, size_t num_elems)
+types::PeriodicUniform<T> periodic_uniform(size_t degree, T begin, T end, size_t num_elems)
 {
   return periodic_uniform<T>(degree, begin, end, num_elems, std::vector<T>(num_elems - 1));
 }
@@ -74,7 +74,7 @@ inline types::PeriodicUniform<T> periodic_uniform(size_t degree, T begin, T end,
  * @return A periodic uniform BSpline.
  */
 template <typename T = double>
-inline types::PeriodicUniform<T> periodic_uniform(size_t degree)
+types::PeriodicUniform<T> periodic_uniform(size_t degree)
 {
   constexpr T begin{ZERO<T>};
   constexpr T end{ONE<T>};
@@ -98,7 +98,7 @@ inline types::PeriodicUniform<T> periodic_uniform(size_t degree)
  * @return A periodic non-uniform BSpline.
  */
 template <typename T = double>
-inline types::PeriodicNonUniform<T>
+types::PeriodicNonUniform<T>
 periodic_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> const &ctrl_points)
 {
   return types::PeriodicNonUniform<T>{
@@ -121,7 +121,7 @@ periodic_nonuniform(size_t degree, std::vector<T> const &knots, std::vector<T> c
  * @return A periodic non-uniform BSpline.
  */
 template <typename T = double>
-inline types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree, std::vector<T> const &knots)
+types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree, std::vector<T> const &knots)
 {
   return periodic_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - 1));
 }
@@ -137,7 +137,7 @@ inline types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree, std::vect
  * @return A periodic non-uniform BSpline.
  */
 template <typename T = double>
-inline types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree)
+types::PeriodicNonUniform<T> periodic_nonuniform(size_t degree)
 {
   std::vector<T> const knots(2 * degree);
   return periodic_nonuniform<T>(degree, knots, std::vector<T>(knots.size() - 1));

--- a/include/BSplineX/bspline/bspline_lsq.hpp
+++ b/include/BSplineX/bspline/bspline_lsq.hpp
@@ -158,28 +158,28 @@ public:
 };
 
 template <typename T>
-struct Condition
+struct InterpolantCondition
 {
   T x_value;
   T y_value;
   size_t derivative_order;
 
-  Condition(T x_value, T y_value, size_t derivative_order)
+  InterpolantCondition(T x_value, T y_value, size_t derivative_order)
       : x_value{x_value}, y_value{y_value}, derivative_order{derivative_order}
   {
   }
 };
 
 template <typename T, class Iter>
-std::vector<Condition<T>> create_sorted_conditions(
+std::vector<InterpolantCondition<T>> create_sorted_conditions(
     views::ArrayView<Iter> const &x,
     views::ArrayView<Iter> const &y,
-    std::vector<Condition<T>> const &additional_conditions
+    std::vector<InterpolantCondition<T>> const &additional_conditions
 )
 {
   debugassert(x.size() == y.size(), "x and y must have the same size.");
 
-  std::vector<Condition<T>> conditions;
+  std::vector<InterpolantCondition<T>> conditions;
   conditions.reserve(x.size() + additional_conditions.size());
 
   for (size_t k{0}; k < x.size(); k++)
@@ -191,7 +191,8 @@ std::vector<Condition<T>> create_sorted_conditions(
   std::sort(
       conditions.begin(),
       conditions.end(),
-      [&](Condition<T> const &a, Condition<T> const &b) { return a.x_value < b.x_value; }
+      [&](InterpolantCondition<T> const &a, InterpolantCondition<T> const &b)
+      { return a.x_value < b.x_value; }
   );
 
   return conditions;
@@ -205,7 +206,7 @@ void fill(
     std::function<size_t(T, size_t, std::vector<T> &)> nnz_basis,
     views::ArrayView<Iter> const &x,
     views::ArrayView<Iter> const &y,
-    std::vector<Condition<T>> const &additional_conditions
+    std::vector<InterpolantCondition<T>> const &additional_conditions
 )
 {
   debugassert(x.size() == y.size(), "x and y must have the same size.");
@@ -217,12 +218,13 @@ void fill(
   size_t const num_rows = A.num_rows();
   size_t const num_cols = A.num_cols();
 
-  std::vector<Condition<T>> conditions = create_sorted_conditions(x, y, additional_conditions);
+  std::vector<InterpolantCondition<T>> conditions =
+      create_sorted_conditions(x, y, additional_conditions);
 
   std::vector<T> nnz(degree + 1, ZERO<T>);
   for (size_t i{0}; i < num_rows; i++)
   {
-    Condition<T> const &condition = conditions.at(i);
+    InterpolantCondition<T> const &condition = conditions.at(i);
 
     size_t const index = nnz_basis(condition.x_value, condition.derivative_order, nnz);
     for (size_t j{0}; j <= degree; j++)
@@ -253,7 +255,7 @@ lsq(size_t const degree,
     std::function<size_t(T, size_t, std::vector<T> &)> nnz_basis,
     views::ArrayView<Iter> const &x,
     views::ArrayView<Iter> const &y,
-    std::vector<Condition<T>> const &additional_conditions)
+    std::vector<InterpolantCondition<T>> const &additional_conditions)
 {
   debugassert(x.size() == y.size(), "x and y must have the same size.");
 

--- a/include/BSplineX/bsplinex.hpp
+++ b/include/BSplineX/bsplinex.hpp
@@ -4,6 +4,7 @@
 #include "BSplineX/bspline/bspline_factory_clamped.hpp"
 #include "BSplineX/bspline/bspline_factory_open.hpp"
 #include "BSplineX/bspline/bspline_factory_periodic.hpp"
+#include "BSplineX/bspline/bspline_lsq.hpp"
 #include "BSplineX/bspline/bspline_types.hpp"
 
 namespace bsplinex
@@ -34,6 +35,8 @@ using types::PeriodicUniform;
 
 using factory::make_periodic_nonuniform;
 using factory::make_periodic_uniform;
+
+using lsq::InterpolantCondition;
 
 } // namespace bsplinex
 

--- a/include/BSplineX/bsplinex.hpp
+++ b/include/BSplineX/bsplinex.hpp
@@ -1,8 +1,40 @@
 #ifndef BSPLINEX_BSPLINEX_HPP
 #define BSPLINEX_BSPLINEX_HPP
 
-#include "BSplineX/bspline/bspline.hpp"
-#include "BSplineX/bspline/bspline_factory.hpp"
+#include "BSplineX/bspline/bspline_factory_clamped.hpp"
+#include "BSplineX/bspline/bspline_factory_open.hpp"
+#include "BSplineX/bspline/bspline_factory_periodic.hpp"
 #include "BSplineX/bspline/bspline_types.hpp"
+
+namespace bsplinex
+{
+
+using types::OpenNonUniform;
+using types::OpenNonUniformConstant;
+using types::OpenUniform;
+using types::OpenUniformConstant;
+
+using factory::open_nonuniform;
+using factory::open_nonuniform_constant;
+using factory::open_uniform;
+using factory::open_uniform_constant;
+
+using types::ClampedNonUniform;
+using types::ClampedNonUniformConstant;
+using types::ClampedUniform;
+using types::ClampedUniformConstant;
+
+using factory::clamped_nonuniform;
+using factory::clamped_nonuniform_constant;
+using factory::clamped_uniform;
+using factory::clamped_uniform_constant;
+
+using types::PeriodicNonUniform;
+using types::PeriodicUniform;
+
+using factory::periodic_nonuniform;
+using factory::periodic_uniform;
+
+} // namespace bsplinex
 
 #endif

--- a/include/BSplineX/bsplinex.hpp
+++ b/include/BSplineX/bsplinex.hpp
@@ -14,26 +14,26 @@ using types::OpenNonUniformConstant;
 using types::OpenUniform;
 using types::OpenUniformConstant;
 
-using factory::open_nonuniform;
-using factory::open_nonuniform_constant;
-using factory::open_uniform;
-using factory::open_uniform_constant;
+using factory::make_open_nonuniform;
+using factory::make_open_nonuniform_constant;
+using factory::make_open_uniform;
+using factory::make_open_uniform_constant;
 
 using types::ClampedNonUniform;
 using types::ClampedNonUniformConstant;
 using types::ClampedUniform;
 using types::ClampedUniformConstant;
 
-using factory::clamped_nonuniform;
-using factory::clamped_nonuniform_constant;
-using factory::clamped_uniform;
-using factory::clamped_uniform_constant;
+using factory::make_clamped_nonuniform;
+using factory::make_clamped_nonuniform_constant;
+using factory::make_clamped_uniform;
+using factory::make_clamped_uniform_constant;
 
 using types::PeriodicNonUniform;
 using types::PeriodicUniform;
 
-using factory::periodic_nonuniform;
-using factory::periodic_uniform;
+using factory::make_periodic_nonuniform;
+using factory::make_periodic_uniform;
 
 } // namespace bsplinex
 

--- a/include/BSplineX/defines.hpp
+++ b/include/BSplineX/defines.hpp
@@ -29,7 +29,7 @@
 
 // some compilers complain about static_assert(false, ...)
 // Use a false_type dependent from a template argument to silence them.
-template <auto>
+template <typename T>
 struct dependent_false : std::false_type
 {
 };

--- a/tests/bspline/test_bspline_with_data.cpp
+++ b/tests/bspline/test_bspline_with_data.cpp
@@ -373,7 +373,7 @@ TEMPLATE_TEST_CASE("BSpline", "[bspline][template][product]", BSPLINE_TEST_TYPES
                                                    .get<std::pair<
                                                        std::vector<std::pair<size_t, real_t>>,
                                                        std::vector<std::pair<size_t, real_t>>>>();
-        std::vector<lsq::Condition<real_t>> additional_conditions{};
+        std::vector<lsq::InterpolantCondition<real_t>> additional_conditions{};
         additional_conditions.reserve(conds_left.size() + conds_right.size());
         for (auto const &[derivative_order, value] : conds_left)
         {


### PR DESCRIPTION
Fixes #10 

Unfortunately the syntax

```cpp
using new_func = foo::old_func;
```

is not possible, especially with templates and overloads. Had to resort to plain

```cpp
using foo::old_func;
```

which works but doesn't allow renaming.

I also did a little cleanup.