### PR TITLE
Made control points constructor take `const &data`

### DIFF
--- a/include/BSplineX/control_points/c_atter.hpp
+++ b/include/BSplineX/control_points/c_atter.hpp
@@ -21,7 +21,7 @@ private:
 public:
   Atter() = default;
 
-  Atter(Data<T> data, size_t degree) : data{std::move(data)}, padder{this->data, degree} {}
+  Atter(Data<T> const &data, size_t degree) : data{data}, padder{this->data, degree} {}
 
   Atter(Atter const &other) = default;
 

--- a/include/BSplineX/control_points/c_data.hpp
+++ b/include/BSplineX/control_points/c_data.hpp
@@ -42,7 +42,7 @@ public:
 
   [[nodiscard]] size_t size() const { return this->raw_data.size(); }
 
-  std::vector<T> slice(size_t first, size_t last)
+  std::vector<T> slice(size_t first, size_t last) const
   {
     debugassert(first <= last, "Invalid range");
     debugassert(last <= this->raw_data.size(), "Out of bounds");

--- a/include/BSplineX/control_points/c_padder.hpp
+++ b/include/BSplineX/control_points/c_padder.hpp
@@ -55,7 +55,7 @@ private:
 public:
   Padder() = default;
 
-  Padder(Data<T> &data, size_t degree) : pad_right{data.slice(0, degree)} {}
+  Padder(Data<T> const &data, size_t degree) : pad_right{data.slice(0, degree)} {}
 
   Padder(Padder const &other) = default;
 

--- a/include/BSplineX/control_points/control_points.hpp
+++ b/include/BSplineX/control_points/control_points.hpp
@@ -41,7 +41,7 @@ private:
 public:
   ControlPoints() = default;
 
-  ControlPoints(Data<T> data, size_t degree) : atter{data, degree}, degree{degree} {}
+  ControlPoints(Data<T> const &data, size_t degree) : atter{data, degree}, degree{degree} {}
 
   ControlPoints(ControlPoints const &other) = default;
 


### PR DESCRIPTION
It must have been by copy due to strange past reasons, it had no right to be.

Fixes #29 