### PR TITLE
Removed `noexcept` from defaulted special methods

### DIFF
--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -102,12 +102,12 @@ public:
    *
    * @param other The BSpline to move from.
    */
-  BSpline(BSpline &&other) noexcept = default;
+  BSpline(BSpline &&other) = default;
 
   /**
    * @brief Destructor.
    */
-  ~BSpline() noexcept = default;
+  ~BSpline() = default;
 
   /**
    * @brief Copy assignment operator.
@@ -141,7 +141,7 @@ public:
    * @param other The BSpline to move from.
    * @return A reference to this BSpline.
    */
-  BSpline &operator=(BSpline &&other) noexcept = default;
+  BSpline &operator=(BSpline &&other) = default;
 
   /**
    * @brief Evaluates the BSpline at a given value.

--- a/include/BSplineX/control_points/c_atter.hpp
+++ b/include/BSplineX/control_points/c_atter.hpp
@@ -25,13 +25,13 @@ public:
 
   Atter(Atter const &other) = default;
 
-  Atter(Atter &&other) noexcept = default;
+  Atter(Atter &&other) = default;
 
-  ~Atter() noexcept = default;
+  ~Atter() = default;
 
   Atter &operator=(Atter const &other) = default;
 
-  Atter &operator=(Atter &&other) noexcept = default;
+  Atter &operator=(Atter &&other) = default;
 
   [[nodiscard]] T at(size_t index) const
   {

--- a/include/BSplineX/control_points/c_data.hpp
+++ b/include/BSplineX/control_points/c_data.hpp
@@ -26,13 +26,13 @@ public:
 
   Data(Data const &other) = default;
 
-  Data(Data &&other) noexcept = default;
+  Data(Data &&other) = default;
 
   ~Data() = default;
 
   Data &operator=(Data const &other) = default;
 
-  Data &operator=(Data &&other) noexcept = default;
+  Data &operator=(Data &&other) = default;
 
   [[nodiscard]] T at(size_t index) const
   {

--- a/include/BSplineX/control_points/c_padder.hpp
+++ b/include/BSplineX/control_points/c_padder.hpp
@@ -23,13 +23,13 @@ public:
 
   Padder(Padder const & /*other*/) = default;
 
-  Padder(Padder && /*other*/) noexcept = default;
+  Padder(Padder && /*other*/) = default;
 
-  ~Padder() noexcept = default;
+  ~Padder() = default;
 
   Padder &operator=(Padder const &other) = default;
 
-  Padder &operator=(Padder &&other) noexcept = default;
+  Padder &operator=(Padder &&other) = default;
 
   [[nodiscard]] T right(size_t /*index*/) const
   {
@@ -59,13 +59,13 @@ public:
 
   Padder(Padder const &other) = default;
 
-  Padder(Padder &&other) noexcept = default;
+  Padder(Padder &&other) = default;
 
-  ~Padder() noexcept = default;
+  ~Padder() = default;
 
   Padder &operator=(Padder const &other) = default;
 
-  Padder &operator=(Padder &&other) noexcept = default;
+  Padder &operator=(Padder &&other) = default;
 
   [[nodiscard]] T right(size_t index) const
   {

--- a/include/BSplineX/control_points/c_padder.hpp
+++ b/include/BSplineX/control_points/c_padder.hpp
@@ -21,9 +21,9 @@ public:
 
   Padder(Data<T> & /*data*/, size_t /*degree*/) {}
 
-  Padder(Padder const & /*other*/) = default;
+  Padder(Padder const &other) = default;
 
-  Padder(Padder && /*other*/) = default;
+  Padder(Padder &&other) = default;
 
   ~Padder() = default;
 

--- a/include/BSplineX/control_points/control_points.hpp
+++ b/include/BSplineX/control_points/control_points.hpp
@@ -45,13 +45,13 @@ public:
 
   ControlPoints(ControlPoints const &other) = default;
 
-  ControlPoints(ControlPoints &&other) noexcept = default;
+  ControlPoints(ControlPoints &&other) = default;
 
-  ~ControlPoints() noexcept = default;
+  ~ControlPoints() = default;
 
   ControlPoints &operator=(ControlPoints const &other) = default;
 
-  ControlPoints &operator=(ControlPoints &&other) noexcept = default;
+  ControlPoints &operator=(ControlPoints &&other) = default;
 
   [[nodiscard]] T at(size_t index) const { return this->atter.at(index); }
 

--- a/include/BSplineX/knots/knots.hpp
+++ b/include/BSplineX/knots/knots.hpp
@@ -59,13 +59,13 @@ public:
 
   Knots(Knots const &other) = default;
 
-  Knots(Knots &&other) noexcept = default;
+  Knots(Knots &&other) = default;
 
   ~Knots() = default;
 
   Knots &operator=(Knots const &other) = default;
 
-  Knots &operator=(Knots &&other) noexcept = default;
+  Knots &operator=(Knots &&other) = default;
 
   [[nodiscard]] std::pair<size_t, T> find(T value) const
   {

--- a/include/BSplineX/knots/t_atter.hpp
+++ b/include/BSplineX/knots/t_atter.hpp
@@ -28,13 +28,13 @@ public:
 
   Atter(Atter const &other) = default;
 
-  Atter(Atter &&other) noexcept = default;
+  Atter(Atter &&other) = default;
 
-  ~Atter() noexcept = default;
+  ~Atter() = default;
 
   Atter &operator=(Atter const &other) = default;
 
-  Atter &operator=(Atter &&other) noexcept = default;
+  Atter &operator=(Atter &&other) = default;
 
   [[nodiscard]] T at(size_t index) const
   {

--- a/include/BSplineX/knots/t_data.hpp
+++ b/include/BSplineX/knots/t_data.hpp
@@ -61,13 +61,13 @@ public:
 
   Data(Data const &other) = default;
 
-  Data(Data &&other) noexcept = default;
+  Data(Data &&other) = default;
 
-  ~Data() noexcept = default;
+  ~Data() = default;
 
   Data &operator=(Data const &other) = default;
 
-  Data &operator=(Data &&other) noexcept = default;
+  Data &operator=(Data &&other) = default;
 
   [[nodiscard]] T at(size_t index) const
   {
@@ -149,13 +149,13 @@ public:
 
   Data(Data const &other) = default;
 
-  Data(Data &&other) noexcept = default;
+  Data(Data &&other) = default;
 
-  ~Data() noexcept = default;
+  ~Data() = default;
 
   Data &operator=(Data const &other) = default;
 
-  Data &operator=(Data &&other) noexcept = default;
+  Data &operator=(Data &&other) = default;
 
   [[nodiscard]] T at(size_t index) const
   {

--- a/include/BSplineX/knots/t_extrapolator.hpp
+++ b/include/BSplineX/knots/t_extrapolator.hpp
@@ -54,13 +54,13 @@ public:
 
   Extrapolator(Extrapolator const &other) = default;
 
-  Extrapolator(Extrapolator &&other) noexcept = default;
+  Extrapolator(Extrapolator &&other) = default;
 
   ~Extrapolator() = default;
 
   Extrapolator &operator=(Extrapolator const &other) = default;
 
-  Extrapolator &operator=(Extrapolator &&other) noexcept = default;
+  Extrapolator &operator=(Extrapolator &&other) = default;
 
   [[nodiscard]] T extrapolate(T value) const
   {
@@ -90,13 +90,13 @@ public:
 
   Extrapolator(Extrapolator const &other) = default;
 
-  Extrapolator(Extrapolator &&other) noexcept = default;
+  Extrapolator(Extrapolator &&other) = default;
 
   ~Extrapolator() = default;
 
   Extrapolator &operator=(Extrapolator const &other) = default;
 
-  Extrapolator &operator=(Extrapolator &&other) noexcept = default;
+  Extrapolator &operator=(Extrapolator &&other) = default;
 
   [[nodiscard]] T extrapolate(T value) const
   {

--- a/include/BSplineX/knots/t_padder.hpp
+++ b/include/BSplineX/knots/t_padder.hpp
@@ -33,9 +33,9 @@ public:
 
   Padder(Data<T, C> const & /*data*/, size_t /*degree*/) {}
 
-  Padder(Padder const & /*other*/) = default;
+  Padder(Padder const &other) = default;
 
-  Padder(Padder && /*other*/) = default;
+  Padder(Padder &&other) = default;
 
   ~Padder() = default;
 

--- a/include/BSplineX/knots/t_padder.hpp
+++ b/include/BSplineX/knots/t_padder.hpp
@@ -35,13 +35,13 @@ public:
 
   Padder(Padder const & /*other*/) = default;
 
-  Padder(Padder && /*other*/) noexcept = default;
+  Padder(Padder && /*other*/) = default;
 
-  ~Padder() noexcept = default;
+  ~Padder() = default;
 
   Padder &operator=(Padder const &other) = default;
 
-  Padder &operator=(Padder &&other) noexcept = default;
+  Padder &operator=(Padder &&other) = default;
 
   [[nodiscard]] T left(size_t /*index*/) const
   {
@@ -94,13 +94,13 @@ public:
 
   Padder(Padder const &other) = default;
 
-  Padder(Padder &&other) noexcept = default;
+  Padder(Padder &&other) = default;
 
-  ~Padder() noexcept = default;
+  ~Padder() = default;
 
   Padder &operator=(Padder const &other) = default;
 
-  Padder &operator=(Padder &&other) noexcept = default;
+  Padder &operator=(Padder &&other) = default;
 
   [[nodiscard]] T left([[maybe_unused]] size_t index) const
   {
@@ -148,13 +148,13 @@ public:
 
   Padder(Padder const &other) = default;
 
-  Padder(Padder &&other) noexcept = default;
+  Padder(Padder &&other) = default;
 
-  ~Padder() noexcept = default;
+  ~Padder() = default;
 
   Padder &operator=(Padder const &other) = default;
 
-  Padder &operator=(Padder &&other) noexcept = default;
+  Padder &operator=(Padder &&other) = default;
 
   [[nodiscard]] T left(size_t index) const
   {

--- a/include/BSplineX/views.hpp
+++ b/include/BSplineX/views.hpp
@@ -69,7 +69,7 @@ public:
    *
    * @param other The ArrayView to move from.
    */
-  ArrayView(ArrayView &&other) noexcept = default;
+  ArrayView(ArrayView &&other) = default;
 
   /**
    * @brief Copy assignment operator.
@@ -89,7 +89,7 @@ public:
    * @param other The ArrayView to move from.
    * @return A reference to this ArrayView.
    */
-  ArrayView &operator=(ArrayView &&other) noexcept = default;
+  ArrayView &operator=(ArrayView &&other) = default;
 
   /**
    * @brief Access an element at a given index with bounds checking.


### PR DESCRIPTION
Fixes #17 

Defaulted special methods (e.g., move constructors) are implicitly `noexcept` if possible (see [standard](https://en.cppreference.com/w/cpp/language/noexcept_spec)).

Given that declaring something `noexcept` randomly does not necessarily result in compiler warnings and may result in abnormal program termination hard to debug, I removed all of them from the defaulted methods. If we use them in the future they must be properly tested.