### PR TITLE
Refactor/naming conventions

### DIFF
--- a/include/BSplineX/bspline/bspline.hpp
+++ b/include/BSplineX/bspline/bspline.hpp
@@ -48,11 +48,11 @@ private:
   using vec_iter       = typename std::vector<T>::iterator;
   using vec_view       = typename views::ArrayView<vec_iter>;
 
-  knots::Knots<T, C, BC, EXT> knots{};
-  control_points::ControlPoints<T, BC> control_points{};
-  size_t degree{};
-  std::vector<T> mutable support{};
-  std::unique_ptr<BSpline const> mutable derivative_ptr;
+  knots::Knots<T, C, BC, EXT> m_knots{};
+  control_points::ControlPoints<T, BC> m_control_points{};
+  size_t m_degree{};
+  std::vector<T> mutable m_support{};
+  std::unique_ptr<BSpline const> mutable m_derivative_ptr;
 
   struct ShallowCopyTag
   {
@@ -81,10 +81,10 @@ public:
       control_points::Data<T> const &control_points_data,
       size_t degree
   )
-      : knots{knots_data, degree}, control_points{control_points_data, degree}, degree{degree}
+      : m_knots{knots_data, degree}, m_control_points{control_points_data, degree}, m_degree{degree}
   {
     this->check_sizes();
-    this->support.resize(this->degree + 1);
+    this->m_support.resize(this->m_degree + 1);
   }
 
   /**
@@ -128,11 +128,11 @@ public:
       return *this;
     }
 
-    this->knots          = other.knots;
-    this->control_points = other.control_points;
-    this->degree         = other.degree;
-    this->support        = other.support;
-    this->derivative_ptr = nullptr;
+    this->m_knots          = other.m_knots;
+    this->m_control_points = other.m_control_points;
+    this->m_degree         = other.m_degree;
+    this->m_support        = other.m_support;
+    this->m_derivative_ptr = nullptr;
     deep_copy_derivative(other);
 
     return *this;
@@ -158,9 +158,8 @@ public:
    */
   bool operator==(BSpline const &other) const
   {
-    return (this->get_degree() == other.get_degree()) and
-           (this->get_knots() == other.get_knots()) and
-           (this->get_control_points() == other.get_control_points());
+    return (this->degree() == other.degree()) and (this->knots() == other.knots()) and
+           (this->control_points() == other.control_points());
   }
 
   /**
@@ -178,7 +177,7 @@ public:
       bspline = this->get_derivative(derivative_order);
     }
 
-    auto [index, x_value] = bspline->knots.find(value);
+    auto [index, x_value] = bspline->m_knots.find(value);
     return bspline->deboor(index, x_value);
   }
 
@@ -229,7 +228,7 @@ public:
 
     basis_functions.insert(basis_functions.begin(), index, ZERO<T>);
     basis_functions.insert(
-        basis_functions.end(), this->control_points.size() - index - this->degree - 1, ZERO<T>
+        basis_functions.end(), this->m_control_points.size() - index - this->m_degree - 1, ZERO<T>
     );
 
     return basis_functions;
@@ -245,7 +244,7 @@ public:
    */
   [[nodiscard]] std::pair<size_t, std::vector<T>> nnz_basis(T value, size_t derivative_order = 0)
   {
-    std::vector<T> nnz(this->degree + 1, ZERO<T>);
+    std::vector<T> nnz(this->m_degree + 1, ZERO<T>);
     size_t const index =
         this->template nnz_basis<vec_iter>(value, derivative_order, {nnz.begin(), nnz.end()});
 
@@ -255,7 +254,7 @@ public:
   /**
    * @brief Gives the (inclusive) boundary of the BSpline domain (i.e., [x_min, x_max])
    */
-  [[nodiscard]] std::pair<T, T> domain() const { return this->knots.domain(); }
+  [[nodiscard]] std::pair<T, T> domain() const { return this->m_knots.domain(); }
 
   /**
    * @brief Fits the BSpline to some data.
@@ -267,10 +266,10 @@ public:
   {
     releaseassert(x.size() == y.size(), "x and y must have the same size");
 
-    this->control_points = std::move(
+    this->m_control_points = std::move(
         lsq::lsq<T, vec_const_iter, BC>(
-            this->degree,
-            this->knots.size(),
+            this->m_degree,
+            this->m_knots.size(),
             [this](T value, size_t derivative_order, std::vector<T> &vec) -> size_t
             {
               return this->nnz_basis<vec_iter>(value, derivative_order, {vec.begin(), vec.end()});
@@ -321,12 +320,12 @@ public:
     else
     {
       releaseassert(
-          additional_conditions.size() == degree - 1,
+          additional_conditions.size() == m_degree - 1,
           "There must be exactly degree - 1 additional conditions."
       );
     }
 
-    knots::Knots<T, C, BC, EXT> new_knots{knots::Data<T, C>{x}, degree};
+    knots::Knots<T, C, BC, EXT> new_knots{knots::Data<T, C>{x}, m_degree};
 
     auto const knots_domain = new_knots.domain();
     releaseassert(
@@ -339,7 +338,7 @@ public:
         "Additional conditions must lie inside the knots interval."
     );
 
-    this->knots = std::move(new_knots);
+    this->m_knots = std::move(new_knots);
 
     vec_const_view x_view;
     vec_const_view y_view;
@@ -347,7 +346,7 @@ public:
     {
       using difference_type = typename vec_const_iter::difference_type;
 
-      auto const shift = static_cast<difference_type>(degree);
+      auto const shift = static_cast<difference_type>(m_degree);
 
       x_view = vec_const_view{std::next(x.begin(), shift), std::prev(x.end(), shift)};
       y_view = vec_const_view{std::next(y.begin(), shift), std::prev(y.end(), shift)};
@@ -370,10 +369,10 @@ public:
       );
     }
 
-    this->control_points = std::move(
+    this->m_control_points = std::move(
         lsq::lsq<T, vec_const_iter, BC>(
-            this->degree,
-            this->knots.size(),
+            this->m_degree,
+            this->m_knots.size(),
             [this](T value, size_t derivative_order, std::vector<T> &vec) -> size_t
             {
               return this->template nnz_basis<vec_iter>(
@@ -389,32 +388,32 @@ public:
     this->invalidate_derivative();
   }
 
-  [[nodiscard]] std::vector<T> get_control_points() const
+  [[nodiscard]] std::vector<T> control_points() const
   {
     std::vector<T> control_points_vec;
-    control_points_vec.reserve(this->control_points.size());
+    control_points_vec.reserve(this->m_control_points.size());
     std::generate_n(
         std::back_inserter(control_points_vec),
-        this->control_points.size(),
-        [this, i = 0]() mutable { return this->control_points.at(i++); }
+        this->m_control_points.size(),
+        [this, i = 0]() mutable { return this->m_control_points.at(i++); }
     );
     return control_points_vec;
   }
 
-  [[nodiscard]] std::vector<T> get_knots() const
+  [[nodiscard]] std::vector<T> knots() const
   {
     std::vector<T> knots_vec;
-    knots_vec.reserve(this->knots.size());
+    knots_vec.reserve(this->m_knots.size());
     std::generate_n(
         std::back_inserter(knots_vec),
-        this->knots.size(),
-        [this, i = 0]() mutable { return this->knots.at(i++); }
+        this->m_knots.size(),
+        [this, i = 0]() mutable { return this->m_knots.at(i++); }
     );
 
     return knots_vec;
   }
 
-  [[nodiscard]] size_t get_degree() const { return this->degree; }
+  [[nodiscard]] size_t degree() const { return this->m_degree; }
 
 private:
   BSpline(
@@ -422,10 +421,10 @@ private:
       control_points::ControlPoints<T, BC> const &control_points,
       size_t degree
   )
-      : knots{knots}, control_points{control_points}, degree{degree}
+      : m_knots{knots}, m_control_points{control_points}, m_degree{degree}
   {
     this->check_sizes();
-    this->support.resize(this->degree + 1);
+    this->m_support.resize(this->m_degree + 1);
   }
 
   /**
@@ -436,21 +435,22 @@ private:
    * @param other The BSpline to copy from.
    */
   BSpline(BSpline const &other, ShallowCopyTag /*unused*/) noexcept
-      : knots(other.knots), control_points(other.control_points), degree(other.degree),
-        support(other.support), derivative_ptr(nullptr)
+      : m_knots(other.m_knots), m_control_points(other.m_control_points), m_degree(other.m_degree),
+        m_support(other.m_support), m_derivative_ptr(nullptr)
   {
   }
 
   void check_sizes()
   {
-    if (this->control_points.size() == this->knots.size() - this->degree - 1)
+    if (this->m_control_points.size() == this->m_knots.size() - this->m_degree - 1)
     {
       return;
     }
 
     std::stringstream ss{};
     ss << "Found control_points.size() != knots.size() - degree - 1 ("
-       << this->control_points.size() << " != " << this->knots.size() - this->degree - 1 << "). ";
+       << this->m_control_points.size() << " != " << this->m_knots.size() - this->m_degree - 1
+       << "). ";
 
     // clang-format off
     if constexpr (BC == BoundaryCondition::OPEN)
@@ -480,7 +480,7 @@ private:
   size_t nnz_basis(T value, size_t derivative_order, vec_view nnz) const
   {
     debugassert(
-        nnz.size() == this->degree + 1,
+        nnz.size() == this->m_degree + 1,
         "Unexpected number of basis asked, exactly degree + 1 basis can be asked"
     );
 
@@ -489,100 +489,102 @@ private:
         "Initial basis must be initialised to zero"
     );
 
-    releaseassert(this->degree >= derivative_order, "Asked for derivative_order > degree");
+    releaseassert(this->m_degree >= derivative_order, "Asked for derivative_order > degree");
 
-    auto [index, val] = this->knots.find(value);
+    auto [index, val] = this->m_knots.find(value);
 
     // Compute the basis of degree - derivative_order
     nnz.back() = 1.0;
-    for (size_t d{1}; d <= this->degree - derivative_order; d++)
+    for (size_t d{1}; d <= this->m_degree - derivative_order; d++)
     {
-      size_t const idx{this->degree - d};
-      nnz.at(idx) = (this->knots.at(index + 1) - val) /
-                    (this->knots.at(index + 1) - this->knots.at(index - d + 1)) * nnz.at(idx + 1);
+      size_t const idx{this->m_degree - d};
+      nnz.at(idx) = (this->m_knots.at(index + 1) - val) /
+                    (this->m_knots.at(index + 1) - this->m_knots.at(index - d + 1)) *
+                    nnz.at(idx + 1);
       for (size_t i{index - d + 1}; i < index; ++i)
       {
-        size_t const idx_in{this->degree - index};
+        size_t const idx_in{this->m_degree - index};
 
-        T const den_1{(this->knots.at(i + d) - this->knots.at(i))};
-        T const den_2{(this->knots.at(i + d + 1) - this->knots.at(i + 1))};
-        T const num_1{val - this->knots.at(i)};
-        T const num_2{this->knots.at(i + d + 1) - val};
+        T const den_1{(this->m_knots.at(i + d) - this->m_knots.at(i))};
+        T const den_2{(this->m_knots.at(i + d + 1) - this->m_knots.at(i + 1))};
+        T const num_1{val - this->m_knots.at(i)};
+        T const num_2{this->m_knots.at(i + d + 1) - val};
         T const basis_1{num_1 / den_1 * nnz.at(idx_in + i)};
         T const basis_2{num_2 / den_2 * nnz.at(idx_in + i + 1)};
 
         nnz.at(idx_in + i) = basis_1 + basis_2;
       }
 
-      T const den_1{this->knots.at(index + d) - this->knots.at(index)};
-      T const num_1{val - this->knots.at(index)};
+      T const den_1{this->m_knots.at(index + d) - this->m_knots.at(index)};
+      T const num_1{val - this->m_knots.at(index)};
 
       nnz.back() = num_1 / den_1 * nnz.back();
     }
 
     // Compute the derivatives up to derivative_order
-    for (size_t p{this->degree + 1 - derivative_order}; p <= this->degree; p++)
+    for (size_t p{this->m_degree + 1 - derivative_order}; p <= this->m_degree; p++)
     {
-      for (size_t i{0}; i < this->degree; i++)
+      for (size_t i{0}; i < this->m_degree; i++)
       {
-        size_t const idx{index - this->degree + i};
+        size_t const idx{index - this->m_degree + i};
 
-        T const den_1{this->knots.at(idx + p) - this->knots.at(idx)};
-        T const den_2{this->knots.at(idx + p + 1) - this->knots.at(idx + 1)};
+        T const den_1{this->m_knots.at(idx + p) - this->m_knots.at(idx)};
+        T const den_2{this->m_knots.at(idx + p + 1) - this->m_knots.at(idx + 1)};
         T const base_1 = den_1 ? p / den_1 * (nnz.at(i)) : ZERO<T>;
         T const base_2 = den_2 ? p / den_2 * (nnz.at(i + 1)) : ZERO<T>;
 
         nnz.at(i) = base_1 - base_2;
       }
 
-      T const den_1{this->knots.at(index + p) - this->knots.at(index)};
+      T const den_1{this->m_knots.at(index + p) - this->m_knots.at(index)};
 
       nnz.back() = den_1 ? p / den_1 * nnz.back() : ZERO<T>;
     }
 
-    return index - this->degree;
+    return index - this->m_degree;
   }
 
   T deboor(size_t index, T value) const
   {
-    for (size_t j = 0; j <= this->degree; j++)
+    for (size_t j = 0; j <= this->m_degree; j++)
     {
-      this->support[j] = this->control_points.at(j + index - this->degree);
+      this->m_support[j] = this->m_control_points.at(j + index - this->m_degree);
     }
 
     T alpha = 0;
-    for (size_t r = 1; r <= this->degree; r++)
+    for (size_t r = 1; r <= this->m_degree; r++)
     {
-      for (size_t j = this->degree; j >= r; --j)
+      for (size_t j = this->m_degree; j >= r; --j)
       {
-        alpha = (value - this->knots.at(j + index - this->degree)) /
-                (this->knots.at(j + 1 + index - r) - this->knots.at(j + index - this->degree));
-        this->support[j] = (1.0 - alpha) * this->support[j - 1] + alpha * this->support[j];
+        alpha =
+            (value - this->m_knots.at(j + index - this->m_degree)) /
+            (this->m_knots.at(j + 1 + index - r) - this->m_knots.at(j + index - this->m_degree));
+        this->m_support[j] = (1.0 - alpha) * this->m_support[j - 1] + alpha * this->m_support[j];
       }
     }
 
-    return this->support[this->degree];
+    return this->m_support[this->m_degree];
   }
 
   BSpline const *get_derivative() const
   {
-    if (not this->derivative_ptr)
+    if (not this->m_derivative_ptr)
     {
-      debugassert(this->degree > 0, "Cannot compute derivative of a 0-degree bspline");
-      this->derivative_ptr = std::unique_ptr<BSpline const>(new BSpline(
-          this->knots.get_derivative_knots(),
-          this->control_points.get_derivative_control_points(this->knots),
-          this->degree - 1
+      debugassert(this->m_degree > 0, "Cannot compute derivative of a 0-degree bspline");
+      this->m_derivative_ptr = std::unique_ptr<BSpline const>(new BSpline(
+          this->m_knots.get_derivative_knots(),
+          this->m_control_points.get_derivative_control_points(this->m_knots),
+          this->m_degree - 1
       ));
     }
 
-    return this->derivative_ptr.get();
+    return this->m_derivative_ptr.get();
   }
 
   BSpline const *get_derivative(size_t derivative_order) const
   {
     releaseassert(
-        (0 < derivative_order) and (derivative_order <= this->degree),
+        (0 < derivative_order) and (derivative_order <= this->m_degree),
         "derivative_order must be in [1, degree]"
     );
     BSpline const *d = this;
@@ -594,23 +596,23 @@ private:
     return d;
   }
 
-  void invalidate_derivative() const { this->derivative_ptr = nullptr; }
+  void invalidate_derivative() const { this->m_derivative_ptr = nullptr; }
 
   void copy_derivative(BSpline const &other) const
   {
-    this->derivative_ptr =
-        std::unique_ptr<BSpline const>(new BSpline(*other.derivative_ptr, ShallowCopyTag{}));
+    this->m_derivative_ptr =
+        std::unique_ptr<BSpline const>(new BSpline(*other.m_derivative_ptr, ShallowCopyTag{}));
   }
 
   void deep_copy_derivative(BSpline const &other) const
   {
     BSpline const *d       = this;
     BSpline const *other_d = &other;
-    for (size_t i{0}; i < degree - 1 and other_d->derivative_ptr; i++)
+    for (size_t i{0}; i < m_degree - 1 and other_d->m_derivative_ptr; i++)
     {
       d->copy_derivative(*other_d);
-      d       = d->derivative_ptr.get();
-      other_d = other_d->derivative_ptr.get();
+      d       = d->m_derivative_ptr.get();
+      other_d = other_d->m_derivative_ptr.get();
     }
   }
 };

--- a/include/BSplineX/bspline/bspline_lsq.hpp
+++ b/include/BSplineX/bspline/bspline_lsq.hpp
@@ -71,17 +71,17 @@ private:
   using mat_t = Eigen::MatrixX<T>;
   using vec_t = Eigen::VectorX<T>;
 
-  mat_t A;
+  mat_t m_A;
 
 public:
-  LSQMatrix(size_t num_rows, size_t num_cols) : A{mat_t::Zero(num_rows, num_cols)} {}
+  LSQMatrix(size_t num_rows, size_t num_cols) : m_A{mat_t::Zero(num_rows, num_cols)} {}
 
-  T &operator()(size_t row, size_t col) { return this->A(row, col); }
+  T &operator()(size_t row, size_t col) { return this->m_A(row, col); }
 
   vec_t solve(vec_t const &b)
   {
     Eigen::LeastSquaresConjugateGradient<mat_t> lscg;
-    lscg.compute(this->A);
+    lscg.compute(this->m_A);
     vec_t x = lscg.solve(b);
 
     // #ifndef NDEBUG
@@ -96,13 +96,13 @@ public:
     return x;
   }
 
-  [[nodiscard]] size_t num_rows() const { return this->A.rows(); }
+  [[nodiscard]] size_t num_rows() const { return this->m_A.rows(); }
 
-  [[nodiscard]] size_t num_cols() const { return this->A.cols(); }
+  [[nodiscard]] size_t num_cols() const { return this->m_A.cols(); }
 
   [[nodiscard]] T conditioning_number() const
   {
-    Eigen::JacobiSVD<mat_t> const svd(this->A);
+    Eigen::JacobiSVD<mat_t> const svd(this->m_A);
     T cond = svd.singularValues()(0) / svd.singularValues()(svd.singularValues().size() - 1);
 
     return cond;
@@ -115,22 +115,22 @@ class LSQMatrix<T, Eigen::SparseMatrix<T>>
 private:
   using mat_t = Eigen::SparseMatrix<T>;
   using vec_t = Eigen::VectorX<T>;
-  mat_t A;
+  mat_t m_A;
 
 public:
-  LSQMatrix(size_t num_rows, size_t num_cols, size_t num_nnz) : A(num_rows, num_cols)
+  LSQMatrix(size_t num_rows, size_t num_cols, size_t num_nnz) : m_A(num_rows, num_cols)
   {
-    this->A.reserve(num_nnz);
+    this->m_A.reserve(num_nnz);
   }
 
-  T &operator()(size_t row, size_t col) { return this->A.coeffRef(row, col); }
+  T &operator()(size_t row, size_t col) { return this->m_A.coeffRef(row, col); }
 
   vec_t solve(vec_t const &b)
   {
-    this->A.makeCompressed();
+    this->m_A.makeCompressed();
 
     Eigen::LeastSquaresConjugateGradient<mat_t> lscg;
-    lscg.compute(this->A);
+    lscg.compute(this->m_A);
     vec_t x = lscg.solve(b);
 
     // #ifndef NDEBUG
@@ -145,9 +145,9 @@ public:
     return x;
   }
 
-  [[nodiscard]] size_t num_rows() const { return A.rows(); }
+  [[nodiscard]] size_t num_rows() const { return m_A.rows(); }
 
-  [[nodiscard]] size_t num_cols() const { return A.cols(); }
+  [[nodiscard]] size_t num_cols() const { return m_A.cols(); }
 
   [[nodiscard]] T conditioning_number() const
   {

--- a/include/BSplineX/control_points/c_atter.hpp
+++ b/include/BSplineX/control_points/c_atter.hpp
@@ -15,13 +15,13 @@ template <typename T, BoundaryCondition BC>
 class Atter
 {
 private:
-  Data<T> data{};
-  Padder<T, BC> padder{};
+  Data<T> m_data{};
+  Padder<T, BC> m_padder{};
 
 public:
   Atter() = default;
 
-  Atter(Data<T> const &data, size_t degree) : data{data}, padder{this->data, degree} {}
+  Atter(Data<T> const &data, size_t degree) : m_data{data}, m_padder{this->m_data, degree} {}
 
   Atter(Atter const &other) = default;
 
@@ -36,37 +36,37 @@ public:
   [[nodiscard]] T at(size_t index) const
   {
     debugassert(index < this->size(), "Out of bounds");
-    if (index < this->data.size())
+    if (index < this->m_data.size())
     {
-      return this->data.at(index);
+      return this->m_data.at(index);
     }
     else
     {
-      return this->padder.right(index - this->data.size());
+      return this->m_padder.right(index - this->m_data.size());
     }
   }
 
-  [[nodiscard]] size_t size() const { return this->data.size() + this->padder.size(); }
+  [[nodiscard]] size_t size() const { return this->m_data.size() + this->m_padder.size(); }
 
   [[nodiscard]] std::vector<T> get_values() const
   {
     std::vector<T> values;
-    values.reserve(data.size() + padder.size());
-    for (size_t i = 0; i < data.size(); i++)
+    values.reserve(m_data.size() + m_padder.size());
+    for (size_t i = 0; i < m_data.size(); i++)
     {
-      values.push_back(data.at(i));
+      values.push_back(m_data.at(i));
     }
-    for (size_t i = 0; i < padder.size(); i++)
+    for (size_t i = 0; i < m_padder.size(); i++)
     {
-      values.push_back(padder.right(i));
+      values.push_back(m_padder.right(i));
     }
     return values;
   }
 
   [[nodiscard]] size_t get_derivative_data_size() const
   {
-    size_t const data_size = this->data.size();
-    return this->padder.size() == 0 ? data_size - 1 : data_size;
+    size_t const data_size = this->m_data.size();
+    return this->m_padder.size() == 0 ? data_size - 1 : data_size;
   }
 };
 

--- a/include/BSplineX/control_points/c_data.hpp
+++ b/include/BSplineX/control_points/c_data.hpp
@@ -17,12 +17,12 @@ template <typename T>
 class Data
 {
 private:
-  std::vector<T> raw_data{};
+  std::vector<T> m_raw_data{};
 
 public:
   Data() = default;
 
-  explicit Data(std::vector<T> const &data) : raw_data{data} {}
+  explicit Data(std::vector<T> const &data) : m_raw_data{data} {}
 
   Data(Data const &other) = default;
 
@@ -36,22 +36,22 @@ public:
 
   [[nodiscard]] T at(size_t index) const
   {
-    debugassert(index < this->raw_data.size(), "Out of bounds");
-    return this->raw_data[index];
+    debugassert(index < this->m_raw_data.size(), "Out of bounds");
+    return this->m_raw_data[index];
   }
 
-  [[nodiscard]] size_t size() const { return this->raw_data.size(); }
+  [[nodiscard]] size_t size() const { return this->m_raw_data.size(); }
 
   std::vector<T> slice(size_t first, size_t last) const
   {
     debugassert(first <= last, "Invalid range");
-    debugassert(last <= this->raw_data.size(), "Out of bounds");
+    debugassert(last <= this->m_raw_data.size(), "Out of bounds");
 
     using difference_type = typename std::vector<T>::iterator::difference_type;
 
     return std::vector<T>{
-        std::next(this->raw_data.begin(), static_cast<difference_type>(first)),
-        std::next(this->raw_data.begin(), static_cast<difference_type>(last))
+        std::next(this->m_raw_data.begin(), static_cast<difference_type>(first)),
+        std::next(this->m_raw_data.begin(), static_cast<difference_type>(last))
     };
   }
 };

--- a/include/BSplineX/control_points/c_padder.hpp
+++ b/include/BSplineX/control_points/c_padder.hpp
@@ -50,12 +50,12 @@ template <typename T>
 class Padder<T, BoundaryCondition::PERIODIC>
 {
 private:
-  std::vector<T> pad_right{};
+  std::vector<T> m_pad_right{};
 
 public:
   Padder() = default;
 
-  Padder(Data<T> const &data, size_t degree) : pad_right{data.slice(0, degree)} {}
+  Padder(Data<T> const &data, size_t degree) : m_pad_right{data.slice(0, degree)} {}
 
   Padder(Padder const &other) = default;
 
@@ -69,13 +69,13 @@ public:
 
   [[nodiscard]] T right(size_t index) const
   {
-    debugassert(index < this->pad_right.size(), "Out of bounds");
-    return this->pad_right.at(index);
+    debugassert(index < this->m_pad_right.size(), "Out of bounds");
+    return this->m_pad_right.at(index);
   }
 
-  [[nodiscard]] size_t size() const { return this->pad_right.size(); }
+  [[nodiscard]] size_t size() const { return this->m_pad_right.size(); }
 
-  [[nodiscard]] size_t size_right() const { return this->pad_right.size(); }
+  [[nodiscard]] size_t size_right() const { return this->m_pad_right.size(); }
 };
 
 } // namespace bsplinex::control_points

--- a/include/BSplineX/control_points/control_points.hpp
+++ b/include/BSplineX/control_points/control_points.hpp
@@ -35,13 +35,13 @@ template <typename T, BoundaryCondition BC>
 class ControlPoints
 {
 private:
-  Atter<T, BC> atter{};
-  size_t degree{};
+  Atter<T, BC> m_atter{};
+  size_t m_degree{};
 
 public:
   ControlPoints() = default;
 
-  ControlPoints(Data<T> const &data, size_t degree) : atter{data, degree}, degree{degree} {}
+  ControlPoints(Data<T> const &data, size_t degree) : m_atter{data, degree}, m_degree{degree} {}
 
   ControlPoints(ControlPoints const &other) = default;
 
@@ -53,26 +53,26 @@ public:
 
   ControlPoints &operator=(ControlPoints &&other) = default;
 
-  [[nodiscard]] T at(size_t index) const { return this->atter.at(index); }
+  [[nodiscard]] T at(size_t index) const { return this->m_atter.at(index); }
 
-  [[nodiscard]] size_t size() const { return this->atter.size(); }
+  [[nodiscard]] size_t size() const { return this->m_atter.size(); }
 
   template <Curve C, Extrapolation EXT>
   [[nodiscard]] ControlPoints
   get_derivative_control_points(knots::Knots<T, C, BC, EXT> const &knots) const
   {
-    size_t const d_num_ctrl_pts = this->atter.get_derivative_data_size();
+    size_t const d_num_ctrl_pts = this->m_atter.get_derivative_data_size();
     std::vector<T> d_ctrl_points;
     d_ctrl_points.reserve(d_num_ctrl_pts);
     for (size_t i = 0; i < d_num_ctrl_pts; i++)
     {
       d_ctrl_points.push_back(
-          static_cast<T>(this->degree) / (knots.at(i + this->degree + 1) - knots.at(i + 1)) *
+          static_cast<T>(this->m_degree) / (knots.at(i + this->m_degree + 1) - knots.at(i + 1)) *
           (this->at(i + 1) - this->at(i))
       );
     }
 
-    return ControlPoints(Data<T>{d_ctrl_points}, this->degree - 1);
+    return ControlPoints(Data<T>{d_ctrl_points}, this->m_degree - 1);
   }
 };
 

--- a/include/BSplineX/knots/knots.hpp
+++ b/include/BSplineX/knots/knots.hpp
@@ -42,18 +42,19 @@ template <typename T, Curve C, BoundaryCondition BC, Extrapolation EXT>
 class Knots
 {
 private:
-  Atter<T, C, BC> atter{};
-  Extrapolator<T, C, BC, EXT> extrapolator{};
-  T value_left{};
-  T value_right{};
-  size_t degree{};
+  Atter<T, C, BC> m_atter{};
+  Extrapolator<T, C, BC, EXT> m_extrapolator{};
+  T m_value_left{};
+  T m_value_right{};
+  size_t m_degree{};
 
 public:
   Knots() = default;
 
   Knots(Data<T, C> const &data, size_t degree)
-      : atter{data, degree}, extrapolator{this->atter, degree}, value_left{this->atter.at(degree)},
-        value_right{this->atter.at(this->atter.size() - degree - 1)}, degree{degree}
+      : m_atter{data, degree}, m_extrapolator{this->m_atter, degree},
+        m_value_left{this->m_atter.at(degree)},
+        m_value_right{this->m_atter.at(this->m_atter.size() - degree - 1)}, m_degree{degree}
   {
   }
 
@@ -69,32 +70,36 @@ public:
 
   [[nodiscard]] std::pair<size_t, T> find(T value) const
   {
-    if (value < this->value_left or value > this->value_right)
+    if (value < this->m_value_left or value > this->m_value_right)
     {
-      value = this->extrapolator.extrapolate(value);
+      value = this->m_extrapolator.extrapolate(value);
     }
 
     return std::pair<size_t, T>{
-        knots::find<T, C, BC, EXT>(this->atter, this->degree, value), value
+        knots::find<T, C, BC, EXT>(this->m_atter, this->m_degree, value), value
     };
   }
 
-  [[nodiscard]] std::pair<T, T> domain() const { return std::make_pair(value_left, value_right); }
+  [[nodiscard]] std::pair<T, T> domain() const
+  {
+    return std::make_pair(m_value_left, m_value_right);
+  }
 
-  [[nodiscard]] T at(size_t index) const { return this->atter.at(index); }
+  [[nodiscard]] T at(size_t index) const { return this->m_atter.at(index); }
 
-  [[nodiscard]] size_t size() const { return this->atter.size(); }
+  [[nodiscard]] size_t size() const { return this->m_atter.size(); }
 
   [[nodiscard]] Knots get_derivative_knots() const
   {
-    Atter<T, C, BC> d_atter = this->atter;
-    return Knots(d_atter.pop_tails(), this->degree - 1);
+    Atter<T, C, BC> d_atter = this->m_atter;
+    return Knots(d_atter.pop_tails(), this->m_degree - 1);
   }
 
 private:
   Knots(Atter<T, C, BC> const &atter, size_t degree)
-      : atter{atter}, extrapolator{this->atter, degree}, value_left{this->atter.at(degree)},
-        value_right{this->atter.at(this->atter.size() - degree - 1)}, degree{degree}
+      : m_atter{atter}, m_extrapolator{this->m_atter, degree},
+        m_value_left{this->m_atter.at(degree)},
+        m_value_right{this->m_atter.at(this->m_atter.size() - degree - 1)}, m_degree{degree}
   {
   }
 };

--- a/include/BSplineX/knots/t_atter.hpp
+++ b/include/BSplineX/knots/t_atter.hpp
@@ -18,13 +18,13 @@ template <typename T, Curve C, BoundaryCondition BC>
 class Atter
 {
 private:
-  Data<T, C> data{};
-  Padder<T, C, BC> padder{};
+  Data<T, C> m_data{};
+  Padder<T, C, BC> m_padder{};
 
 public:
   Atter() = default;
 
-  Atter(Data<T, C> const &data, size_t degree) : data{data}, padder{this->data, degree} {}
+  Atter(Data<T, C> const &data, size_t degree) : m_data{data}, m_padder{this->m_data, degree} {}
 
   Atter(Atter const &other) = default;
 
@@ -39,31 +39,31 @@ public:
   [[nodiscard]] T at(size_t index) const
   {
     debugassert(index < this->size(), "Out of bounds");
-    if (index < this->padder.size_left())
+    if (index < this->m_padder.size_left())
     {
-      return this->padder.left(index);
+      return this->m_padder.left(index);
     }
-    else if (index > this->data.size() - 1 + this->padder.size_left())
+    else if (index > this->m_data.size() - 1 + this->m_padder.size_left())
     {
-      return this->padder.right(index - this->data.size() - this->padder.size_left());
+      return this->m_padder.right(index - this->m_data.size() - this->m_padder.size_left());
     }
     else
     {
-      return this->data.at(index - this->padder.size_left());
+      return this->m_data.at(index - this->m_padder.size_left());
     }
   }
 
-  [[nodiscard]] size_t size() const { return this->data.size() + this->padder.size(); }
+  [[nodiscard]] size_t size() const { return this->m_data.size() + this->m_padder.size(); }
 
   Atter &pop_tails()
   {
-    if (this->padder.size() > 0)
+    if (this->m_padder.size() > 0)
     {
-      this->padder.pop_tails();
+      this->m_padder.pop_tails();
     }
     else
     {
-      this->data.pop_tails();
+      this->m_data.pop_tails();
     }
 
     return *this;
@@ -72,8 +72,8 @@ public:
   class iterator
   {
   private:
-    Atter const *atter{nullptr};
-    size_t index{0};
+    Atter const *m_atter{nullptr};
+    size_t m_index{0};
 
   public:
     // iterator traits
@@ -83,7 +83,7 @@ public:
     using reference         = T const &;
     using iterator_category = std::random_access_iterator_tag;
 
-    iterator(Atter<T, C, BC> const *atter, size_t index) : atter{atter}, index{index} {}
+    iterator(Atter<T, C, BC> const *atter, size_t index) : m_atter{atter}, m_index{index} {}
 
     ~iterator() = default;
 
@@ -97,7 +97,7 @@ public:
 
     iterator &operator++()
     {
-      ++(this->index);
+      ++(this->m_index);
       return *this;
     }
 
@@ -110,7 +110,7 @@ public:
 
     iterator &operator--()
     {
-      --(this->index);
+      --(this->m_index);
       return *this;
     }
 
@@ -123,7 +123,7 @@ public:
 
     iterator &operator+=(difference_type n)
     {
-      this->index += n;
+      this->m_index += n;
       return *this;
     }
 
@@ -136,7 +136,7 @@ public:
 
     iterator &operator-=(difference_type n)
     {
-      this->index -= n;
+      this->m_index -= n;
       return *this;
     }
 
@@ -149,20 +149,20 @@ public:
 
     difference_type operator-(iterator const &b) const
     {
-      return static_cast<difference_type>(this->index - b.index);
+      return static_cast<difference_type>(this->m_index - b.m_index);
     }
 
-    bool operator==(iterator const &other) const { return this->index == other.index; }
+    bool operator==(iterator const &other) const { return this->m_index == other.m_index; }
 
     bool operator!=(iterator const &other) const { return !(*this == other); }
 
-    value_type operator*() const { return this->atter->at(this->index); }
+    value_type operator*() const { return this->m_atter->at(this->m_index); }
 
     value_type operator[](difference_type n) const { return *(*this + n); }
 
-    bool operator<(iterator const &b) const { return this->index < b.index; }
+    bool operator<(iterator const &b) const { return this->m_index < b.m_index; }
 
-    bool operator>(iterator const &b) const { return this->index > b.index; }
+    bool operator>(iterator const &b) const { return this->m_index > b.m_index; }
 
     bool operator<=(iterator const &b) const { return !(*this > b); }
 

--- a/include/BSplineX/knots/t_data.hpp
+++ b/include/BSplineX/knots/t_data.hpp
@@ -30,10 +30,10 @@ template <typename T>
 class Data<T, Curve::UNIFORM>
 {
 private:
-  T begin{};
-  T end{};
-  size_t num_elems{0};
-  T step_size{};
+  T m_begin{};
+  T m_end{};
+  size_t m_num_elems{0};
+  T m_step_size{};
 
 public:
   Data() = default;
@@ -42,10 +42,10 @@ public:
   {
     releaseassert(Data::is_uniform(data), "Data must be uniform with step > 0");
 
-    this->begin     = data.front();
-    this->end       = data.back();
-    this->num_elems = data.size();
-    this->step_size = (this->end - this->begin) / (this->num_elems - 1);
+    this->m_begin     = data.front();
+    this->m_end       = data.back();
+    this->m_num_elems = data.size();
+    this->m_step_size = (this->m_end - this->m_begin) / (this->m_num_elems - 1);
   }
 
   // Specifying the num-elems means the domain will be [begin, end]
@@ -53,10 +53,10 @@ public:
   {
     debugassert(begin < end, "Wrong interval");
 
-    this->begin     = begin;
-    this->end       = end;
-    this->num_elems = num_elems;
-    this->step_size = (end - begin) / (num_elems - 1);
+    this->m_begin     = begin;
+    this->m_end       = end;
+    this->m_num_elems = num_elems;
+    this->m_step_size = (end - begin) / (num_elems - 1);
   }
 
   Data(Data const &other) = default;
@@ -71,16 +71,16 @@ public:
 
   [[nodiscard]] T at(size_t index) const
   {
-    debugassert(index < this->num_elems, "Out of bounds");
-    return std::fma<T>(static_cast<T>(index), this->step_size, this->begin);
+    debugassert(index < this->m_num_elems, "Out of bounds");
+    return std::fma<T>(static_cast<T>(index), this->m_step_size, this->m_begin);
   }
 
-  [[nodiscard]] size_t size() const { return this->num_elems; }
+  [[nodiscard]] size_t size() const { return this->m_num_elems; }
 
   [[nodiscard]] std::vector<T> slice(size_t first, size_t last) const
   {
     debugassert(first <= last, "Invalid range");
-    debugassert(last <= this->num_elems, "Out of bounds");
+    debugassert(last <= this->m_num_elems, "Out of bounds");
 
     std::vector<T> tmp{};
     tmp.reserve(last - first);
@@ -93,10 +93,10 @@ public:
 
   void pop_tails()
   {
-    debugassert(this->num_elems >= 2, "Cannot pop tails from a domain with less than 2 elements");
-    this->begin     += this->step_size;
-    this->end       -= this->step_size;
-    this->num_elems -= 2;
+    debugassert(this->m_num_elems >= 2, "Cannot pop tails from a domain with less than 2 elements");
+    this->m_begin     += this->m_step_size;
+    this->m_end       -= this->m_step_size;
+    this->m_num_elems -= 2;
   }
 
 private:
@@ -132,12 +132,12 @@ template <typename T>
 class Data<T, Curve::NON_UNIFORM>
 {
 private:
-  std::vector<T> raw_data{};
+  std::vector<T> m_raw_data{};
 
 public:
   Data() = default;
 
-  explicit Data(std::vector<T> const &data) : raw_data(data)
+  explicit Data(std::vector<T> const &data) : m_raw_data(data)
   {
     // NOTE: thank the STL for this wonderful backwards built sort check. Think it as if std::less
     // is <= and std::less_equal is <.
@@ -159,32 +159,32 @@ public:
 
   [[nodiscard]] T at(size_t index) const
   {
-    debugassert(index < this->raw_data.size(), "Out of bounds");
-    return this->raw_data[index];
+    debugassert(index < this->m_raw_data.size(), "Out of bounds");
+    return this->m_raw_data[index];
   }
 
-  [[nodiscard]] size_t size() const { return this->raw_data.size(); }
+  [[nodiscard]] size_t size() const { return this->m_raw_data.size(); }
 
   [[nodiscard]] std::vector<T> slice(size_t first, size_t last) const
   {
     debugassert(first <= last, "Invalid range");
-    debugassert(last <= this->raw_data.size(), "Out of bounds");
+    debugassert(last <= this->m_raw_data.size(), "Out of bounds");
 
     using difference_type = typename std::vector<T>::iterator::difference_type;
 
     return std::vector<T>{
-        std::next(this->raw_data.begin(), static_cast<difference_type>(first)),
-        std::next(this->raw_data.begin(), static_cast<difference_type>(last))
+        std::next(this->m_raw_data.begin(), static_cast<difference_type>(first)),
+        std::next(this->m_raw_data.begin(), static_cast<difference_type>(last))
     };
   }
 
   void pop_tails()
   {
     debugassert(
-        this->raw_data.size() >= 2, "Cannot pop tails from a domain with less than 2 elements"
+        this->m_raw_data.size() >= 2, "Cannot pop tails from a domain with less than 2 elements"
     );
-    this->raw_data.pop_back();
-    this->raw_data.erase(this->raw_data.begin());
+    this->m_raw_data.pop_back();
+    this->m_raw_data.erase(this->m_raw_data.begin());
   }
 };
 

--- a/include/BSplineX/knots/t_extrapolator.hpp
+++ b/include/BSplineX/knots/t_extrapolator.hpp
@@ -41,14 +41,14 @@ template <typename T, Curve C, BoundaryCondition BC>
 class Extrapolator<T, C, BC, Extrapolation::CONSTANT>
 {
 private:
-  T value_left{};
-  T value_right{};
+  T m_value_left{};
+  T m_value_right{};
 
 public:
   Extrapolator() = default;
 
   Extrapolator(Atter<T, C, BC> const &atter, size_t degree)
-      : value_left{atter.at(degree)}, value_right{atter.at(atter.size() - degree - 1)}
+      : m_value_left{atter.at(degree)}, m_value_right{atter.at(atter.size() - degree - 1)}
   {
   }
 
@@ -65,9 +65,9 @@ public:
   [[nodiscard]] T extrapolate(T value) const
   {
     debugassert(
-        value < this->value_left or value > this->value_right, "Value not outside of the domain"
+        value < this->m_value_left or value > this->m_value_right, "Value not outside of the domain"
     );
-    return value < this->value_left ? this->value_left : this->value_right;
+    return value < this->m_value_left ? this->m_value_left : this->m_value_right;
   }
 };
 
@@ -75,16 +75,16 @@ template <typename T, Curve C, BoundaryCondition BC>
 class Extrapolator<T, C, BC, Extrapolation::PERIODIC>
 {
 private:
-  T value_left{};
-  T value_right{};
-  T period{};
+  T m_value_left{};
+  T m_value_right{};
+  T m_period{};
 
 public:
   Extrapolator() = default;
 
   Extrapolator(Atter<T, C, BC> const &atter, size_t degree)
-      : value_left{atter.at(degree)}, value_right{atter.at(atter.size() - degree - 1)},
-        period{this->value_right - this->value_left}
+      : m_value_left{atter.at(degree)}, m_value_right{atter.at(atter.size() - degree - 1)},
+        m_period{this->m_value_right - this->m_value_left}
   {
   }
 
@@ -101,17 +101,17 @@ public:
   [[nodiscard]] T extrapolate(T value) const
   {
     debugassert(
-        value < this->value_left or value > this->value_right, "Value not outside of the domain"
+        value < this->m_value_left or value > this->m_value_right, "Value not outside of the domain"
     );
 
-    T wrapped = std::fmod<T>(value - this->value_left, this->period);
+    T wrapped = std::fmod<T>(value - this->m_value_left, this->m_period);
 
     if (wrapped < constants::ZERO<T>)
     {
-      wrapped += this->period;
+      wrapped += this->m_period;
     }
 
-    return wrapped + this->value_left;
+    return wrapped + this->m_value_left;
   }
 };
 

--- a/include/BSplineX/knots/t_padder.hpp
+++ b/include/BSplineX/knots/t_padder.hpp
@@ -80,15 +80,15 @@ template <typename T, Curve C>
 class Padder<T, C, BoundaryCondition::CLAMPED>
 {
 private:
-  T pad_left{};
-  T pad_right{};
-  size_t pad_size{0};
+  T m_pad_left{};
+  T m_pad_right{};
+  size_t m_pad_size{0};
 
 public:
   Padder() = default;
 
   Padder(Data<T, C> const &data, size_t degree)
-      : pad_left{data.at(0)}, pad_right{data.at(data.size() - 1)}, pad_size{degree}
+      : m_pad_left{data.at(0)}, m_pad_right{data.at(data.size() - 1)}, m_pad_size{degree}
   {
   }
 
@@ -104,45 +104,45 @@ public:
 
   [[nodiscard]] T left([[maybe_unused]] size_t index) const
   {
-    debugassert(index < this->pad_size, "Out of bounds");
-    return this->pad_left;
+    debugassert(index < this->m_pad_size, "Out of bounds");
+    return this->m_pad_left;
   }
 
   [[nodiscard]] T right([[maybe_unused]] size_t index) const
   {
-    debugassert(index < this->pad_size, "Out of bounds");
-    return this->pad_right;
+    debugassert(index < this->m_pad_size, "Out of bounds");
+    return this->m_pad_right;
   }
 
   [[nodiscard]] size_t size() const { return this->size_left() + this->size_right(); }
 
-  [[nodiscard]] size_t size_left() const { return this->pad_size; }
+  [[nodiscard]] size_t size_left() const { return this->m_pad_size; }
 
-  [[nodiscard]] size_t size_right() const { return this->pad_size; }
+  [[nodiscard]] size_t size_right() const { return this->m_pad_size; }
 
-  void pop_tails() { --this->pad_size; }
+  void pop_tails() { --this->m_pad_size; }
 };
 
 template <typename T, Curve C>
 class Padder<T, C, BoundaryCondition::PERIODIC>
 {
 private:
-  std::vector<T> pad_left{};
-  std::vector<T> pad_right{};
+  std::vector<T> m_pad_left{};
+  std::vector<T> m_pad_right{};
 
 public:
   Padder() = default;
 
   Padder(Data<T, C> const &data, size_t degree)
-      : pad_left{data.slice(data.size() - degree - 1, data.size() - 1)},
-        pad_right{data.slice(1, degree + 1)}
+      : m_pad_left{data.slice(data.size() - degree - 1, data.size() - 1)},
+        m_pad_right{data.slice(1, degree + 1)}
 
   {
     T period = data.at(data.size() - 1) - data.at(0);
     for (size_t i{0}; i < degree; i++)
     {
-      this->pad_left.at(i)  -= period;
-      this->pad_right.at(i) += period;
+      this->m_pad_left.at(i)  -= period;
+      this->m_pad_right.at(i) += period;
     }
   }
 
@@ -158,28 +158,28 @@ public:
 
   [[nodiscard]] T left(size_t index) const
   {
-    debugassert(index < this->pad_left.size(), "Out of bounds");
-    return this->pad_left.at(index);
+    debugassert(index < this->m_pad_left.size(), "Out of bounds");
+    return this->m_pad_left.at(index);
   }
 
   [[nodiscard]] T right(size_t index) const
   {
-    debugassert(index < this->pad_right.size(), "Out of bounds");
-    return this->pad_right.at(index);
+    debugassert(index < this->m_pad_right.size(), "Out of bounds");
+    return this->m_pad_right.at(index);
   }
 
   [[nodiscard]] size_t size() const { return this->size_left() + this->size_right(); }
 
-  [[nodiscard]] size_t size_left() const { return this->pad_left.size(); }
+  [[nodiscard]] size_t size_left() const { return this->m_pad_left.size(); }
 
-  [[nodiscard]] size_t size_right() const { return this->pad_right.size(); }
+  [[nodiscard]] size_t size_right() const { return this->m_pad_right.size(); }
 
   void pop_tails()
   {
-    debugassert(not this->pad_left.empty(), "Cannot pop tails from an empty domain");
-    debugassert(not this->pad_right.empty(), "Cannot pop tails from an empty domain");
-    this->pad_left.erase(this->pad_left.begin());
-    this->pad_right.pop_back();
+    debugassert(not this->m_pad_left.empty(), "Cannot pop tails from an empty domain");
+    debugassert(not this->m_pad_right.empty(), "Cannot pop tails from an empty domain");
+    this->m_pad_left.erase(this->m_pad_left.begin());
+    this->m_pad_right.pop_back();
   }
 };
 

--- a/include/BSplineX/views.hpp
+++ b/include/BSplineX/views.hpp
@@ -21,8 +21,8 @@ template <class Iter>
 class ArrayView
 {
 private:
-  Iter _begin;
-  Iter _end;
+  Iter m_begin;
+  Iter m_end;
 
   using difference_type = typename std::iterator_traits<Iter>::difference_type;
   using reference       = typename std::iterator_traits<Iter>::reference;
@@ -47,7 +47,7 @@ public:
    * @param end The iterator pointing to the end of the range.
    * @throw in debug mode if end is not greater than begin.
    */
-  ArrayView(Iter begin, Iter end) : _begin{begin}, _end{end}
+  ArrayView(Iter begin, Iter end) : m_begin{begin}, m_end{end}
   {
     releaseassert(end > begin, "Invalid view range.");
   }
@@ -99,7 +99,7 @@ public:
    */
   reference at(difference_type index)
   {
-    releaseassert(std::distance(this->_begin, this->_end) > index, "Out of bounds.");
+    releaseassert(std::distance(this->m_begin, this->m_end) > index, "Out of bounds.");
     releaseassert(index >= 0, "Negative indices are not supported.");
 
     return this->operator[](index);
@@ -111,21 +111,21 @@ public:
    * @param index The index of the element to access.
    * @return A reference to the element at the specified index.
    */
-  reference operator[](difference_type index) { return *std::next(this->_begin, index); }
+  reference operator[](difference_type index) { return *std::next(this->m_begin, index); }
 
   /**
    * @brief Get the first element of the view
    *
    * @return a reference to the first element of the view
    */
-  reference front() { return *(this->_begin); }
+  reference front() { return *(this->m_begin); }
 
   /**
    * @brief Get the last element of the view
    *
    * @return a reference to the last element of the view
    */
-  reference back() { return *std::prev(this->_end, 1); }
+  reference back() { return *std::prev(this->m_end, 1); }
 
   /**
    * @brief Get the number of elements in the view.
@@ -134,7 +134,7 @@ public:
    */
   [[nodiscard]] size_t size() const
   {
-    return static_cast<size_t>(std::distance(this->_begin, this->_end));
+    return static_cast<size_t>(std::distance(this->m_begin, this->m_end));
   }
 
   /**
@@ -142,14 +142,14 @@ public:
    *
    * @return the begin iterator
    */
-  [[nodiscard]] Iter begin() { return this->_begin; }
+  [[nodiscard]] Iter begin() { return this->m_begin; }
 
   /**
    * @brief Get the end iterator
    *
    * @return the end iterator
    */
-  [[nodiscard]] Iter end() { return this->_end; }
+  [[nodiscard]] Iter end() { return this->m_end; }
 };
 
 } // namespace bsplinex::views

--- a/tests/bspline/test_bspline_with_data.cpp
+++ b/tests/bspline/test_bspline_with_data.cpp
@@ -272,7 +272,7 @@ TEMPLATE_TEST_CASE("BSpline", "[bspline][template][product]", BSPLINE_TEST_TYPES
           {
             BSplineType const derivative = bspline.derivative(derivative_order);
             auto const y_eval_d          = derivative_data["y_eval"].get<std::vector<real_t>>();
-            REQUIRE(derivative.get_degree() == derivative_data["degree"].get<size_t>());
+            REQUIRE(derivative.degree() == derivative_data["degree"].get<size_t>());
             REQUIRE_THAT(derivative.evaluate(x_eval), VectorsWithinAbsRel(y_eval_d));
           }
           derivative_data = derivative_data["derivative"];
@@ -356,14 +356,14 @@ TEMPLATE_TEST_CASE("BSpline", "[bspline][template][product]", BSPLINE_TEST_TYPES
         auto const &bspline_data = test_data["bspline_fit"];
 
         auto const knots_fit = bspline_data["knots"].get<std::vector<real_t>>();
-        REQUIRE_THAT(bspline.get_knots(), VectorsWithinAbsRel(knots_fit));
+        REQUIRE_THAT(bspline.knots(), VectorsWithinAbsRel(knots_fit));
         if (BoundaryCondition::PERIODIC == BSplineType::boundary_condition_type)
         {
           SKIP("SciPy currently does not support fitting for periodic BSplines");
         }
 
         auto const ctrl_pts_fit = bspline_data["ctrl"].get<std::vector<real_t>>();
-        REQUIRE_THAT(bspline.get_control_points(), VectorsWithinAbsRel(ctrl_pts_fit));
+        REQUIRE_THAT(bspline.control_points(), VectorsWithinAbsRel(ctrl_pts_fit));
 
         auto derivative_data = bspline_data;
         for (size_t derivative_order = 0; derivative_order <= degree; ++derivative_order)
@@ -445,8 +445,8 @@ TEMPLATE_TEST_CASE("BSpline", "[bspline][template][product]", BSPLINE_TEST_TYPES
                 test_data["bspline_interp"]["ctrl"].get<std::vector<real_t>>();
             auto const y_eval_interp = derivative_data["y_eval"].get<std::vector<real_t>>();
 
-            REQUIRE_THAT(bspline.get_knots(), VectorsWithinAbsRel(knots_interp));
-            REQUIRE_THAT(bspline.get_control_points(), VectorsWithinAbsRel(ctrl_pts_interp));
+            REQUIRE_THAT(bspline.knots(), VectorsWithinAbsRel(knots_interp));
+            REQUIRE_THAT(bspline.control_points(), VectorsWithinAbsRel(ctrl_pts_interp));
             real_t const interp_data_tol = derivative_order == 0 ? RTOL<real_t> : 1e-5;
             REQUIRE_THAT(
                 derivative.evaluate(x_eval),
@@ -479,7 +479,7 @@ TEMPLATE_TEST_CASE("BSpline", "[bspline][template][product]", BSPLINE_TEST_TYPES
         auto require_equals = [&bspline_base](BSplineType const &actual)
         {
           REQUIRE(actual == bspline_base);
-          for (size_t derivative_order{1}; derivative_order <= bspline_base.get_degree();
+          for (size_t derivative_order{1}; derivative_order <= bspline_base.degree();
                derivative_order++)
           {
             REQUIRE(


### PR DESCRIPTION
Fix #45.

Add `m_` prefix to class member variables and rename `BSpline` getters to `knots()`, `control_points()`, and `degree()`.